### PR TITLE
chore: add Bee client starter with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ export CHROME_BIN=/usr/bin/chromium-browser
 
 In Visual Studio environment, the tests have been set up to run against your local bee node on `http://localhost:1633`
 To run Jest tests, choose the `vscode-jest-tests` CI job under the Run tab.
+You can run your own local Bee client for test purposes with the help of [test/bee.sh](test/bee.sh).
+If you pass `--ephemeral` flag, the container automatically will be removed at the end of the run.
 
 ### Compile code
 

--- a/test/bee.sh
+++ b/test/bee.sh
@@ -1,21 +1,28 @@
 #!/bin/sh
-if [ ! -d /tmp/bee ] ; then
-   mkdir -p /tmp/bee/data && \
-   chown $(id -u):999 -R /tmp/bee && \
-   chmod 770 -R /tmp/bee && \
-   echo "password" > /tmp/bee/password
+# --ephemeral -> create ephemeral container for bee-client. Data won't be persisted
+BEE_CONTAINER=`docker container ls -qaf name=bee-test`
+if [ -z $BEE_CONTAINER ] || [ "$1" = "--ephemeral" ] ; then
+  BEE_IMAGE="ethersphere/bee:0.4.0"
+  BEE_PASSWORD="password"
+  CONTAINER_NAME="bee-test"
+  EXTRA_PARAMS=" --name $CONTAINER_NAME"
+  if [ "$1" = "--ephemeral" ] ; then
+    EXTRA_PARAMS=" --rm"
+  fi
+  docker run \
+    -p 127.0.0.1:1635:1635 \
+    -p 127.0.0.1:1634:1634 \
+    -p 127.0.0.1:1633:1633 \
+    --interactive \
+    --tty \
+    $EXTRA_PARAMS \
+    $BEE_IMAGE \
+      start \
+      --password $BEE_PASSWORD \
+      --standalone=true \
+      --swap-enable=false \
+      --debug-api-enable \
+      --cors-allowed-origins="*"
+else
+  docker start -ai $BEE_CONTAINER
 fi
-docker run $@ \
-  -p 1635:1635 \
-  -p 1634:1634 \
-  -p 1633:1633 \
-  --volume /tmp/bee:/bee \
-  --interactive \
-  --tty \
-  "ethersphere/bee:0.4.0" \
-    start \
-    --data-dir /bee/data \
-    --password-file /bee/password \
-    --standalone=true \
-    --swap-enable=false \
-    --cors-allowed-origins="*"

--- a/test/bee.sh
+++ b/test/bee.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+if [ ! -d /tmp/bee ] ; then
+   mkdir -p /tmp/bee/data && \
+   chown $(id -u):999 -R /tmp/bee && \
+   chmod 770 -R /tmp/bee && \
+   echo "password" > /tmp/bee/password
+fi
+docker run $@ \
+  -p 1635:1635 \
+  -p 1634:1634 \
+  -p 1633:1633 \
+  --volume /tmp/bee:/bee \
+  --interactive \
+  --tty \
+  "ethersphere/bee:0.4.0" \
+    start \
+    --data-dir /bee/data \
+    --password-file /bee/password \
+    --standalone=true \
+    --swap-enable=false \
+    --cors-allowed-origins="*"


### PR DESCRIPTION
In order to have unified test results, we need the same Bee client configuration to do tests.

This PR adds a little Bash script, which starts a Bee client with the appropriate configurations for run local tests.

## TODO
- [x] - Amend `README` about this

extends #37