### PR TITLE
feat: pinning for files and collections

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import type { Readable } from 'stream'
 import * as file from './modules/file'
-import * as tag from './modules/tag'
 import * as collection from './modules/collection'
+import * as tag from './modules/tag'
+import * as pinning from './modules/pinning'
 import { Tag, FileData, Reference } from './types'
 
 /**
@@ -121,5 +122,41 @@ export default class Bee {
    */
   retrieveTag(tagUid: number | Tag): Promise<Tag> {
     return tag.retrieveTag(this.url, tagUid)
+  }
+
+  /**
+   * Pin file with given reference
+   *
+   * @param reference Bee file reference
+   */
+  pinFile(reference: Reference): Promise<pinning.Response> {
+    return pinning.pinFile(this.url, reference)
+  }
+
+  /**
+   * Unpin file with given reference
+   *
+   * @param reference Bee file reference
+   */
+  unpinFile(reference: Reference): Promise<pinning.Response> {
+    return pinning.unpinFile(this.url, reference)
+  }
+
+  /**
+   * Pin collection with given reference
+   *
+   * @param reference Bee collection reference
+   */
+  pinCollection(reference: Reference): Promise<pinning.Response> {
+    return pinning.pinCollection(this.url, reference)
+  }
+
+  /**
+   * Unpin collection with given reference
+   *
+   * @param reference Bee collection reference
+   */
+  unpinCollection(reference: Reference): Promise<pinning.Response> {
+    return pinning.unpinCollection(this.url, reference)
   }
 }

--- a/src/modules/pinning.ts
+++ b/src/modules/pinning.ts
@@ -1,0 +1,73 @@
+import { safeAxios } from '../utils/safeAxios'
+
+const fileEndpoint = '/pin/files'
+const collectionEndpoint = '/pin/bzz'
+
+export interface Response {
+  message: string
+  code: number
+}
+
+/**
+ * Pin file with given reference
+ *
+ * @param url  Bee URL
+ * @param hash Bee file reference
+ */
+export async function pinFile(url: string, hash: string): Promise<Response> {
+  const response = await safeAxios<Response>({
+    method: 'post',
+    responseType: 'json',
+    url: `${url}${fileEndpoint}/${hash}`,
+  })
+
+  return response.data
+}
+
+/**
+ * Unpin file with given reference
+ *
+ * @param url  Bee URL
+ * @param hash Bee file reference
+ */
+export async function unpinFile(url: string, hash: string): Promise<Response> {
+  const response = await safeAxios<Response>({
+    method: 'delete',
+    responseType: 'json',
+    url: `${url}${fileEndpoint}/${hash}`,
+  })
+
+  return response.data
+}
+
+/**
+ * Pin collection with given reference
+ *
+ * @param url  Bee URL
+ * @param hash Bee collection reference
+ */
+export async function pinCollection(url: string, hash: string): Promise<Response> {
+  const response = await safeAxios<Response>({
+    method: 'post',
+    responseType: 'json',
+    url: `${url}${collectionEndpoint}/${hash}`,
+  })
+
+  return response.data
+}
+
+/**
+ * Unpin collection with given reference
+ *
+ * @param url  Bee URL
+ * @param hash Bee collection reference
+ */
+export async function unpinCollection(url: string, hash: string): Promise<Response> {
+  const response = await safeAxios<Response>({
+    method: 'delete',
+    responseType: 'json',
+    url: `${url}${collectionEndpoint}/${hash}`,
+  })
+
+  return response.data
+}

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -14,8 +14,16 @@ function readContentDispositionFilename(header?: string): string {
     if (!header) {
       throw new BeeError('missing content-disposition header')
     }
+<<<<<<< HEAD
+<<<<<<< HEAD
     // Regex was found here
     // https://stackoverflow.com/questions/23054475/javascript-regex-for-extracting-filename-from-content-disposition-header
+=======
+>>>>>>> edca6d6 (feat: tar upload in the browser)
+=======
+    // Regex was found here
+    // https://stackoverflow.com/questions/23054475/javascript-regex-for-extracting-filename-from-content-disposition-header
+>>>>>>> 2fe3f2c (chore: add comments)
     const dispositionMatch = header.match(/filename\*?=['"]?(?:UTF-\d['"]*)?([^;\r\n"']*)['"]?;?/i)
 
     if (dispositionMatch && dispositionMatch.length > 0) {

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -14,16 +14,8 @@ function readContentDispositionFilename(header?: string): string {
     if (!header) {
       throw new BeeError('missing content-disposition header')
     }
-<<<<<<< HEAD
-<<<<<<< HEAD
     // Regex was found here
     // https://stackoverflow.com/questions/23054475/javascript-regex-for-extracting-filename-from-content-disposition-header
-=======
->>>>>>> edca6d6 (feat: tar upload in the browser)
-=======
-    // Regex was found here
-    // https://stackoverflow.com/questions/23054475/javascript-regex-for-extracting-filename-from-content-disposition-header
->>>>>>> 2fe3f2c (chore: add comments)
     const dispositionMatch = header.match(/filename\*?=['"]?(?:UTF-\d['"]*)?([^;\r\n"']*)['"]?;?/i)
 
     if (dispositionMatch && dispositionMatch.length > 0) {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -23,4 +23,19 @@ describe('Bee class', () => {
 
     expect(tag).toEqual(tag2)
   })
+
+  it('should pin and unping files', async () => {
+    const content = new Uint8Array([1, 2, 3])
+
+    const hash = await bee.uploadFile(content)
+    await bee.pinFile(hash)
+    await bee.unpinFile(hash)
+  })
+
+  it('should pin and unping collection', async () => {
+    const path = './test/data/'
+    const hash = await bee.uploadFilesFromDirectory(path)
+    await bee.pinCollection(hash)
+    await bee.unpinCollection(hash)
+  })
 })

--- a/test/modules/file.spec.ts
+++ b/test/modules/file.spec.ts
@@ -1,6 +1,6 @@
 import * as File from '../../src/modules/file'
 import * as Tag from '../../src/modules/tag'
-import { beeUrl, createReadable, randomBuffer } from '../utils'
+import { beeUrl, createReadable, randomByteArray } from '../utils'
 
 const BEE_URL = beeUrl()
 
@@ -26,7 +26,7 @@ describe('modules/file', () => {
   })
 
   it('should store readable file', async () => {
-    const data = randomBuffer(5000)
+    const data = randomByteArray(5000)
     const filename = 'hello.txt'
 
     const hash = await File.upload(BEE_URL, createReadable(data), filename, {
@@ -38,7 +38,7 @@ describe('modules/file', () => {
   })
 
   it('should store file with a tag', async () => {
-    const data = randomBuffer(5000)
+    const data = randomByteArray(5000)
     const filename = 'hello.txt'
 
     const tag = await Tag.createTag(BEE_URL)

--- a/test/modules/file.spec.ts
+++ b/test/modules/file.spec.ts
@@ -1,5 +1,5 @@
-import * as File from '../../src/modules/file'
-import * as Tag from '../../src/modules/tag'
+import * as file from '../../src/modules/file'
+import * as tag from '../../src/modules/tag'
 import { beeUrl, createReadable, randomByteArray } from '../utils'
 
 const BEE_URL = beeUrl()
@@ -9,41 +9,41 @@ describe('modules/file', () => {
     const data = 'hello world'
     const filename = 'hello.txt'
 
-    const hash = await File.upload(BEE_URL, data, filename)
-    const file = await File.download(BEE_URL, hash)
+    const hash = await file.upload(BEE_URL, data, filename)
+    const fileData = await file.download(BEE_URL, hash)
 
-    expect(Buffer.from(file.data).toString()).toEqual(data)
-    expect(file.name).toEqual(filename)
+    expect(Buffer.from(fileData.data).toString()).toEqual(data)
+    expect(fileData.name).toEqual(filename)
   })
 
   it('should store file without filename', async () => {
     const data = 'hello world'
 
-    const hash = await File.upload(BEE_URL, data)
-    const file = await File.download(BEE_URL, hash)
+    const hash = await file.upload(BEE_URL, data)
+    const fileData = await file.download(BEE_URL, hash)
 
-    expect(Buffer.from(file.data).toString()).toEqual(data)
+    expect(Buffer.from(fileData.data).toString()).toEqual(data)
   })
 
   it('should store readable file', async () => {
     const data = randomByteArray(5000)
     const filename = 'hello.txt'
 
-    const hash = await File.upload(BEE_URL, createReadable(data), filename, {
+    const hash = await file.upload(BEE_URL, createReadable(data), filename, {
       size: data.length,
     })
-    const file = await File.download(BEE_URL, hash)
+    const fileData = await file.download(BEE_URL, hash)
 
-    expect(file.data).toEqual(data)
+    expect(fileData.data).toEqual(data)
   })
 
   it('should store file with a tag', async () => {
     const data = randomByteArray(5000)
     const filename = 'hello.txt'
 
-    const tag = await Tag.createTag(BEE_URL)
-    await File.upload(BEE_URL, data, filename, { tag: tag.uid })
-    const tag2 = await Tag.retrieveTag(BEE_URL, tag)
+    const tag1 = await tag.createTag(BEE_URL)
+    await file.upload(BEE_URL, data, filename, { tag: tag1.uid })
+    const tag2 = await tag.retrieveTag(BEE_URL, tag1)
 
     expect(tag2.split).toEqual(5)
     expect(tag2.stored).toEqual(5)
@@ -52,6 +52,6 @@ describe('modules/file', () => {
   it('should catch error', async () => {
     const invalidReference = '0000000000000000000000000000000000000000000000000000000000000000'
 
-    await expect(File.download(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+    await expect(file.download(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
   })
 })

--- a/test/modules/pinning.spec.ts
+++ b/test/modules/pinning.spec.ts
@@ -8,6 +8,10 @@ const BEE_URL = beeUrl()
 
 describe('modules/pin', () => {
   const invalidReference = '0000000000000000000000000000000000000000000000000000000000000000'
+  const okResponse = {
+    code: 200,
+    message: 'OK',
+  }
 
   describe('should work with files', () => {
     const randomData = randomByteArray(5000)
@@ -16,14 +20,14 @@ describe('modules/pin', () => {
       const hash = await file.upload(BEE_URL, randomData)
       const response = await pinning.pinFile(BEE_URL, hash)
 
-      expect(response.code).toBe(200)
+      expect(response).toEqual(okResponse)
     })
 
     it('should unpin an existing file', async () => {
       const hash = await file.upload(BEE_URL, randomData)
       const response = await pinning.unpinFile(BEE_URL, hash)
 
-      expect(response.code).toBe(200)
+      expect(response).toEqual(okResponse)
     })
 
     it('should not pin a non-existing file', async () => {
@@ -51,14 +55,14 @@ describe('modules/pin', () => {
       const hash = await collection.upload(BEE_URL, testCollection)
       const response = await pinning.pinCollection(BEE_URL, hash)
 
-      expect(response.code).toBe(200)
+      expect(response).toEqual(okResponse)
     })
 
     it('should unpin an existing file', async () => {
       const hash = await collection.upload(BEE_URL, testCollection)
       const response = await pinning.unpinCollection(BEE_URL, hash)
 
-      expect(response.code).toBe(200)
+      expect(response).toEqual(okResponse)
     })
 
     it('should not pin a non-existing file', async () => {

--- a/test/modules/pinning.spec.ts
+++ b/test/modules/pinning.spec.ts
@@ -1,0 +1,72 @@
+import * as pinning from '../../src/modules/pinning'
+import * as file from '../../src/modules/file'
+import * as collection from '../../src/modules/collection'
+import { beeUrl, randomByteArray } from '../utils'
+import { Collection } from '../../src/types'
+
+const BEE_URL = beeUrl()
+
+describe('modules/pin', () => {
+  const invalidReference = '0000000000000000000000000000000000000000000000000000000000000000'
+
+  describe('should work with files', () => {
+    const randomData = randomByteArray(5000)
+
+    it('should pin an existing file', async () => {
+      const hash = await file.upload(BEE_URL, randomData)
+      const response = await pinning.pinFile(BEE_URL, hash)
+
+      expect(response.code).toBe(200)
+    })
+
+    it('should unpin an existing file', async () => {
+      const hash = await file.upload(BEE_URL, randomData)
+      const response = await pinning.unpinFile(BEE_URL, hash)
+
+      expect(response.code).toBe(200)
+    })
+
+    it('should not pin a non-existing file', async () => {
+      await expect(pinning.pinFile(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+    })
+
+    it('should not unpin a non-existing file', async () => {
+      await expect(pinning.unpinFile(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+    })
+  })
+
+  describe('should work with collections', () => {
+    const testCollection: Collection<Uint8Array> = [
+      {
+        path: '0',
+        data: Uint8Array.from([0]),
+      },
+      {
+        path: '1',
+        data: Uint8Array.from([1]),
+      },
+    ]
+
+    it('should pin an existing collection', async () => {
+      const hash = await collection.upload(BEE_URL, testCollection)
+      const response = await pinning.pinCollection(BEE_URL, hash)
+
+      expect(response.code).toBe(200)
+    })
+
+    it('should unpin an existing file', async () => {
+      const hash = await collection.upload(BEE_URL, testCollection)
+      const response = await pinning.unpinCollection(BEE_URL, hash)
+
+      expect(response.code).toBe(200)
+    })
+
+    it('should not pin a non-existing file', async () => {
+      await expect(pinning.pinCollection(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+    })
+
+    it('should not unpin a non-existing file', async () => {
+      await expect(pinning.unpinCollection(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+    })
+  })
+})

--- a/test/modules/tag.spec.ts
+++ b/test/modules/tag.spec.ts
@@ -1,28 +1,28 @@
-import * as Tag from '../../src/modules/tag'
+import * as tag from '../../src/modules/tag'
 import { beeUrl } from '../utils'
 
 const BEE_URL = beeUrl()
 
 describe('modules/tag', () => {
   it('should create empty tag', async () => {
-    const tag = await Tag.createTag(BEE_URL)
+    const tag1 = await tag.createTag(BEE_URL)
 
-    expect(tag.total).toBe(0)
-    expect(tag.split).toBe(0)
-    expect(tag.seen).toBe(0)
-    expect(tag.stored).toBe(0)
-    expect(tag.sent).toBe(0)
-    expect(tag.synced).toBe(0)
-    expect(Number.isInteger(tag.uid)).toBeTruthy()
-    expect(typeof tag.name).toBe('string')
-    expect(tag.address).toBe('')
-    expect(typeof tag.startedAt).toBe('string')
+    expect(tag1.total).toBe(0)
+    expect(tag1.split).toBe(0)
+    expect(tag1.seen).toBe(0)
+    expect(tag1.stored).toBe(0)
+    expect(tag1.sent).toBe(0)
+    expect(tag1.synced).toBe(0)
+    expect(Number.isInteger(tag1.uid)).toBeTruthy()
+    expect(typeof tag1.name).toBe('string')
+    expect(tag1.address).toBe('')
+    expect(typeof tag1.startedAt).toBe('string')
   })
 
   it('should retrieve previously created empty tag', async () => {
-    const tag = await Tag.createTag(BEE_URL)
-    const tag2 = await Tag.retrieveTag(BEE_URL, tag)
+    const tag1 = await tag.createTag(BEE_URL)
+    const tag2 = await tag.retrieveTag(BEE_URL, tag1)
 
-    expect(tag).toEqual(expect.objectContaining(tag2))
+    expect(tag1).toEqual(tag2)
   })
 })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -38,7 +38,7 @@ function lrng(seed: number): () => number {
  * @param length Number of bytes to generate
  * @param seed Seed for the pseudo-random generator
  */
-export function randomBuffer(length: number, seed = 500): Uint8Array {
+export function randomByteArray(length: number, seed = 500): Uint8Array {
   const rand = lrng(seed)
   const buf = new Uint8Array(length)
 


### PR DESCRIPTION
This PR adds the pinning functionality for files and collections. It doesn't add the functionality for bytes and chunks because they are not part of the JS API yet.

This means that once we add the chunks functionality then we will need to add pinning for it as well and it has more endpoint than just post and delete. Regarding bytes: we may completely avoid to add it because currently it's not very different from files without a filename.

