### PR TITLE
feat: pss send and subscribe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2673,6 +2673,15 @@
         }
       }
     },
+    "@types/ws": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.0.tgz",
+      "integrity": "sha512-Y29uQ3Uy+58bZrFLhX36hcI3Np37nqWE7ky5tjiDoy1GDZnIwVxS0CgF+s+1bXMzjKBFy+fqaRfb708iNzdinw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "15.0.11",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
@@ -6480,6 +6489,11 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
     },
     "isstream": {
       "version": "0.1.2",
@@ -11885,8 +11899,7 @@
     "ws": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
-      "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ==",
-      "dev": true
+      "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
   },
   "dependencies": {
     "axios": "^0.21.0",
-    "tar-js": "^0.3.0"
+    "isomorphic-ws": "^4.0.1",
+    "tar-js": "^0.3.0",
+    "ws": "^7.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",
@@ -58,6 +60,7 @@
     "@types/terser-webpack-plugin": "^5.0.2",
     "@types/webpack": "^4.41.25",
     "@types/webpack-bundle-analyzer": "^3.9.0",
+    "@types/ws": "^7.4.0",
     "@types/yargs-parser": "^15.0.0",
     "@typescript-eslint/eslint-plugin": "^4.8.2",
     "@typescript-eslint/parser": "^4.8.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -289,6 +289,16 @@ export class Bee {
   /**
    * Receive message with Postal Service for Swarm
    *
+   * Because sending a PSS message is slow and CPU intensive,
+   * it is not supposed to be used for general messaging but
+   * most likely for setting up an encrypted communication
+   * channel by sending a one-off message.
+   *
+   * This is a helper function to wait for exactly one message to
+   * arrive and then cancel the subscription. Additionally a
+   * timeout can be provided for the message to arrive or else
+   * an error will be thrown.
+   *
    * @param topic Topic name
    * @param timeoutMsec Timeout in milliseconds
    *

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,8 @@ import * as collection from './modules/collection'
 import * as tag from './modules/tag'
 import * as pinning from './modules/pinning'
 import * as bytes from './modules/bytes'
-import { Tag, FileData, Reference, UploadOptions } from './types'
+import * as pss from './modules/pss'
+import { Tag, FileData, Reference, UploadOptions, PublicKey } from './types'
 
 /**
  * The Bee class provides a way of interacting with the Bee APIs based on the provided url
@@ -208,6 +209,19 @@ export class Bee {
    */
   unpinData(reference: Reference): Promise<pinning.Response> {
     return pinning.unpinData(this.url, reference)
+  }
+
+  /**
+   * Send to recipient or target with Postal Service for Swarm
+   *
+   * @param topic Topic name
+   * @param target Target message address prefix
+   * @param data Message to be sent
+   * @param recipient Recipient public key
+   *
+   */
+  pssSend(topic: string, target: string, data: string | Uint8Array, recipient?: PublicKey): Promise<pss.Response> {
+    return pss.send(this.url, topic, target, data, recipient)
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -270,7 +270,11 @@ export class Bee {
 
     ws.onmessage = ev => {
       const data = new Uint8Array(Buffer.from(ev.data))
-      handler.onMessage(data, subscription)
+
+      // ignore empty messages
+      if (data.length > 0) {
+        handler.onMessage(data, subscription)
+      }
     }
     ws.onerror = ev => {
       // ignore errors after subscription was cancelled

--- a/src/index.ts
+++ b/src/index.ts
@@ -282,8 +282,8 @@ export class Bee {
   pssReceive(topic: string, timeoutMsec = 60000): Promise<Uint8Array> {
     return new Promise((resolve, reject) => {
       const subscription = this.pssSubscribe(topic, {
-        onError: (error) => reject(error.message),
-        onMessage: (message) => {
+        onError: error => reject(error.message),
+        onMessage: message => {
           subscription.cancel()
           resolve(message)
         },

--- a/src/modules/debug/connectivity.ts
+++ b/src/modules/debug/connectivity.ts
@@ -1,0 +1,34 @@
+import { safeAxios } from '../../utils/safeAxios'
+
+interface NodeAddresses {
+  overlay: string
+  underlay: string[]
+  ethereum: string
+  public_key: string
+  pss_public_key: string
+}
+
+export async function getNodeAddresses(url: string): Promise<NodeAddresses> {
+  const response = await safeAxios<NodeAddresses>({
+    url: url + '/addresses',
+    responseType: 'json',
+  })
+
+  return response.data
+}
+
+interface Peer {
+  address: string
+}
+interface Peers {
+  peers: Peer[]
+}
+
+export async function getPeers(url: string): Promise<Peers> {
+  const response = await safeAxios<Peers>({
+    url: url + '/peers',
+    responseType: 'json',
+  })
+
+  return response.data
+}

--- a/src/modules/debug/connectivity.ts
+++ b/src/modules/debug/connectivity.ts
@@ -1,6 +1,6 @@
 import { safeAxios } from '../../utils/safeAxios'
 
-interface NodeAddresses {
+export interface NodeAddresses {
   overlay: string
   underlay: string[]
   ethereum: string
@@ -17,10 +17,10 @@ export async function getNodeAddresses(url: string): Promise<NodeAddresses> {
   return response.data
 }
 
-interface Peer {
+export interface Peer {
   address: string
 }
-interface Peers {
+export interface Peers {
   peers: Peer[]
 }
 

--- a/src/modules/pss.ts
+++ b/src/modules/pss.ts
@@ -1,11 +1,15 @@
+import WebSocket from 'isomorphic-ws'
+
 import { PublicKey } from '../types'
 import { prepareData } from '../utils/data'
 import { safeAxios } from '../utils/safeAxios'
 
 const endpoint = '/pss'
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface Response {}
+export interface Response {
+  message: string
+  code: number
+}
 
 /**
  * Send to recipient or target with Postal Service for Swarm
@@ -40,5 +44,7 @@ export async function send(
  * @param topic Topic name
  */
 export function subscribe(url: string, topic: string): WebSocket {
-  return new WebSocket(`${url}${endpoint}/subscribe/${topic}`)
+  const wsUrl = url.replace(/^http/i, 'ws')
+
+  return new WebSocket(`${wsUrl}${endpoint}/subscribe/${topic}`)
 }

--- a/src/modules/pss.ts
+++ b/src/modules/pss.ts
@@ -1,12 +1,11 @@
-import { PublicKey } from "../types"
-import { prepareData } from "../utils/data"
-import { safeAxios } from "../utils/safeAxios"
+import { PublicKey } from '../types'
+import { prepareData } from '../utils/data'
+import { safeAxios } from '../utils/safeAxios'
 
 const endpoint = '/pss'
 
-export interface Response {
-
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Response {}
 
 /**
  * Send to recipient or target with Postal Service for Swarm
@@ -22,7 +21,7 @@ export async function send(
   topic: string,
   target: string,
   data: string | Uint8Array,
-  recipient?: PublicKey
+  recipient?: PublicKey,
 ): Promise<Response> {
   const response = await safeAxios<Response>({
     method: 'post',

--- a/src/modules/pss.ts
+++ b/src/modules/pss.ts
@@ -1,0 +1,45 @@
+import { PublicKey } from "../types"
+import { prepareData } from "../utils/data"
+import { safeAxios } from "../utils/safeAxios"
+
+const endpoint = '/pss'
+
+export interface Response {
+
+}
+
+/**
+ * Send to recipient or target with Postal Service for Swarm
+ *
+ * @param url Bee url
+ * @param topic Topic name
+ * @param target Target message address prefix
+ * @param recipient Recipient public key
+ *
+ */
+export async function send(
+  url: string,
+  topic: string,
+  target: string,
+  data: string | Uint8Array,
+  recipient?: PublicKey
+): Promise<Response> {
+  const response = await safeAxios<Response>({
+    method: 'post',
+    url: `${url}${endpoint}/send/${topic}/${target.slice(0, 4)}`,
+    data: await prepareData(data),
+    responseType: 'json',
+    params: { recipient },
+  })
+
+  return response.data
+}
+
+/**
+ * Subscribe for messages on the given topic
+ *
+ * @param topic Topic name
+ */
+export function subscribe(url: string, topic: string): WebSocket {
+  return new WebSocket(`${url}${endpoint}/subscribe/${topic}`)
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,7 @@ export interface Dictionary<T> {
 }
 
 export type Reference = string
+export type PublicKey = string
 
 export const REFERENCE_LENGTH = 64
 export const ENCRYPTED_REFERENCE_LENGTH = 2 * REFERENCE_LENGTH

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,9 +1,14 @@
+import { BeeError } from '../utils/error'
+
 export interface Dictionary<T> {
   [Key: string]: T
 }
 
 export type Reference = string
 export type PublicKey = string
+
+export type Address = string
+export type AddressPrefix = Address
 
 export const REFERENCE_LENGTH = 64
 export const ENCRYPTED_REFERENCE_LENGTH = 2 * REFERENCE_LENGTH
@@ -59,3 +64,13 @@ export interface CollectionEntry<T> {
  * Represents Collections
  */
 export type Collection<T> = Array<CollectionEntry<T>>
+
+export interface PssSubscription {
+  readonly topic: string
+  cancel: () => void
+}
+
+export interface PssMessageHandler {
+  onMessage: (message: Uint8Array) => void
+  onError: (error: BeeError) => void
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -71,6 +71,6 @@ export interface PssSubscription {
 }
 
 export interface PssMessageHandler {
-  onMessage: (message: Uint8Array) => void
-  onError: (error: BeeError) => void
+  onMessage: (message: Uint8Array, subscription: PssSubscription) => void
+  onError: (error: BeeError, subscription: PssSubscription) => void
 }

--- a/test/bee-class.spec.ts
+++ b/test/bee-class.spec.ts
@@ -79,7 +79,7 @@ describe('Bee class', () => {
         done()
       })
 
-      beePeer.pssSend(topic, address, message)
+      await beePeer.pssSend(topic, address, message)
     }, 60000)
 
     it('should send and receive data with public key', async done => {
@@ -96,7 +96,7 @@ describe('Bee class', () => {
         done()
       })
 
-      beePeer.pssSend(topic, address, message, pssPublicKey)
+      await beePeer.pssSend(topic, address, message, pssPublicKey)
     }, 60000)
 
     it('receive should time out', async () => {
@@ -123,7 +123,7 @@ describe('Bee class', () => {
         },
       })
 
-      beePeer.pssSend(topic, address, message)
+      await beePeer.pssSend(topic, address, message)
     }, 60000)
   })
 })

--- a/test/bee-class.spec.ts
+++ b/test/bee-class.spec.ts
@@ -66,37 +66,40 @@ describe('Bee class', () => {
   })
 
   describe('pss', () => {
-    it('should send and receive data', async done => {
+    it('should send and receive data', done => {
       const topic = 'bee-class-topic'
       const message = new Uint8Array([1, 2, 3])
-
       const beeDebug = new BeeDebug(beeDebugUrl())
-      const address = await beeDebug.getOverlayAddress()
-      const beePeer = new Bee(beePeerUrl())
 
       bee.pssReceive(topic).then(receivedMessage => {
         expect(receivedMessage).toEqual(message)
         done()
       })
 
-      await beePeer.pssSend(topic, address, message)
+      return beeDebug.getOverlayAddress().then(address => {
+        const beePeer = new Bee(beePeerUrl())
+
+        return beePeer.pssSend(topic, address, message)
+      })
     }, 60000)
 
-    it('should send and receive data with public key', async done => {
-      const topic = 'bee-class-topic'
+    it('should send and receive data with public key', done => {
+      const topic = 'bee-class-topic-publickey'
       const message = new Uint8Array([1, 2, 3])
-
       const beeDebug = new BeeDebug(beeDebugUrl())
-      const address = await beeDebug.getOverlayAddress()
-      const pssPublicKey = await beeDebug.getPssPublicKey()
-      const beePeer = new Bee(beePeerUrl())
 
       bee.pssReceive(topic).then(receivedMessage => {
         expect(receivedMessage).toEqual(message)
         done()
       })
 
-      await beePeer.pssSend(topic, address, message, pssPublicKey)
+      return beeDebug.getOverlayAddress().then(address => {
+        return beeDebug.getPssPublicKey().then(pssPublicKey => {
+          const beePeer = new Bee(beePeerUrl())
+
+          return beePeer.pssSend(topic, address, message, pssPublicKey)
+        })
+      })
     }, 60000)
 
     it('receive should time out', async () => {
@@ -105,13 +108,10 @@ describe('Bee class', () => {
       await expect(bee.pssReceive(topic, 1)).rejects.toThrow('pssReceive timeout')
     })
 
-    it('should subscribe to topic', async done => {
+    it('should subscribe to topic', done => {
       const topic = 'bee-class-subscribe-topic'
       const message = new Uint8Array([1, 2, 3])
-
       const beeDebug = new BeeDebug(beeDebugUrl())
-      const address = await beeDebug.getOverlayAddress()
-      const beePeer = new Bee(beePeerUrl())
 
       bee.pssSubscribe(topic, {
         onMessage: receivedMessage => {
@@ -123,7 +123,11 @@ describe('Bee class', () => {
         },
       })
 
-      await beePeer.pssSend(topic, address, message)
+      return beeDebug.getOverlayAddress().then(address => {
+        const beePeer = new Bee(beePeerUrl())
+
+        return beePeer.pssSend(topic, address, message)
+      })
     }, 60000)
   })
 })

--- a/test/bee-class.spec.ts
+++ b/test/bee-class.spec.ts
@@ -114,9 +114,10 @@ describe('Bee class', () => {
 
         const subscription = bee.pssSubscribe(topic, {
           onMessage: receivedMessage => {
-            expect(receivedMessage).toEqual(message)
-            // without cancel jest complains for leaking handles
+            // without cancel jest complains for leaking handles and may hang
             subscription.cancel()
+
+            expect(receivedMessage).toEqual(message)
             done()
           },
           onError: e => {

--- a/test/modules/pinning.spec.ts
+++ b/test/modules/pinning.spec.ts
@@ -2,17 +2,12 @@ import * as pinning from '../../src/modules/pinning'
 import * as file from '../../src/modules/file'
 import * as collection from '../../src/modules/collection'
 import * as bytes from '../../src/modules/bytes'
-import { beeUrl, invalidReference, randomByteArray } from '../utils'
+import { beeUrl, invalidReference, okResponse, randomByteArray } from '../utils'
 import { Collection } from '../../src/types'
 
 const BEE_URL = beeUrl()
 
 describe('modules/pin', () => {
-  const okResponse = {
-    code: 200,
-    message: 'OK',
-  }
-
   describe('should work with files', () => {
     const randomData = randomByteArray(5000)
 

--- a/test/modules/pss.spec.ts
+++ b/test/modules/pss.spec.ts
@@ -12,7 +12,7 @@ describe('modules/pss', () => {
   it(
     'should send PSS message',
     async () => {
-      const topic = 'topic'
+      const topic = 'send-pss-message'
       const message = 'hello'
 
       const debugUrl = beeDebugUrl()
@@ -29,8 +29,8 @@ describe('modules/pss', () => {
 
   it(
     'should send and receive PSS message',
-    async done => {
-      const topic = 'topic'
+    done => {
+      const topic = 'send-receive-pss-message'
       const message = 'hello'
 
       const ws = pss.subscribe(BEE_URL, topic)
@@ -41,18 +41,20 @@ describe('modules/pss', () => {
       }
 
       const debugUrl = beeDebugUrl()
-      const addresses = await connectivity.getNodeAddresses(debugUrl)
-      const target = addresses.overlay
 
-      await pss.send(BEE_PEER_URL, topic, target, message)
+      return connectivity.getNodeAddresses(debugUrl).then(addresses => {
+        const target = addresses.overlay
+
+        return pss.send(BEE_PEER_URL, topic, target, message)
+      })
     },
     PSS_TIMEOUT,
   )
 
   it(
     'should send and receive PSS message with public key',
-    async done => {
-      const topic = 'topic'
+    done => {
+      const topic = 'send-receive-pss-public-key'
       const message = 'hello'
 
       const ws = pss.subscribe(BEE_URL, topic)
@@ -63,11 +65,13 @@ describe('modules/pss', () => {
       }
 
       const debugUrl = beeDebugUrl()
-      const addresses = await connectivity.getNodeAddresses(debugUrl)
-      const target = addresses.overlay
-      const recipient = addresses.pss_public_key
 
-      await pss.send(BEE_PEER_URL, topic, target, message, recipient)
+      return connectivity.getNodeAddresses(debugUrl).then(addresses => {
+        const target = addresses.overlay
+        const recipient = addresses.pss_public_key
+
+        return pss.send(BEE_PEER_URL, topic, target, message, recipient)
+      })
     },
     PSS_TIMEOUT,
   )

--- a/test/modules/pss.spec.ts
+++ b/test/modules/pss.spec.ts
@@ -33,8 +33,14 @@ describe('modules/pss', () => {
 
       const ws = pss.subscribe(BEE_URL, topic)
       ws.onmessage = ev => {
+        const receivedMessage = Buffer.from(ev.data).toString()
+
+        // ignore empty messages
+        if (receivedMessage.length === 0) {
+          return
+        }
         ws.terminate()
-        expect(Buffer.from(ev.data).toString()).toEqual(message)
+        expect(receivedMessage).toEqual(message)
         done()
       }
 
@@ -55,8 +61,14 @@ describe('modules/pss', () => {
 
       const ws = pss.subscribe(BEE_URL, topic)
       ws.onmessage = ev => {
+        const receivedMessage = Buffer.from(ev.data).toString()
+
+        // ignore empty messages
+        if (receivedMessage.length === 0) {
+          return
+        }
         ws.terminate()
-        expect(Buffer.from(ev.data).toString()).toEqual(message)
+        expect(receivedMessage).toEqual(message)
         done()
       }
 

--- a/test/modules/pss.spec.ts
+++ b/test/modules/pss.spec.ts
@@ -1,0 +1,13 @@
+import * as pss from '../../src/modules/pss'
+import { beeUrl } from '../utils'
+
+const BEE_URL = beeUrl()
+
+describe('modules/pss', () => {
+  it('should send PSS message', async (done) => {
+    const topic = 'pss topic'
+    const target = '0f9c'
+    const message = 'hello'
+    const response = await pss.send(BEE_URL, topic, target, message)
+  })
+})

--- a/test/modules/pss.spec.ts
+++ b/test/modules/pss.spec.ts
@@ -33,8 +33,8 @@ describe('modules/pss', () => {
 
       const ws = pss.subscribe(BEE_URL, topic)
       ws.onmessage = ev => {
-        expect(Buffer.from(ev.data).toString()).toEqual(message)
         ws.terminate()
+        expect(Buffer.from(ev.data).toString()).toEqual(message)
         done()
       }
 
@@ -55,8 +55,8 @@ describe('modules/pss', () => {
 
       const ws = pss.subscribe(BEE_URL, topic)
       ws.onmessage = ev => {
-        expect(Buffer.from(ev.data).toString()).toEqual(message)
         ws.terminate()
+        expect(Buffer.from(ev.data).toString()).toEqual(message)
         done()
       }
 

--- a/test/modules/pss.spec.ts
+++ b/test/modules/pss.spec.ts
@@ -1,13 +1,74 @@
 import * as pss from '../../src/modules/pss'
-import { beeUrl } from '../utils'
+import * as connectivity from '../../src/modules/debug/connectivity'
+import { beeDebugUrl, beePeerUrl, beeUrl, okResponse } from '../utils'
 
 const BEE_URL = beeUrl()
+const BEE_PEER_URL = beePeerUrl()
 
+const PSS_TIMEOUT = 60000
+
+// these tests only work when there is at least one peer connected
 describe('modules/pss', () => {
-  it('should send PSS message', async () => {
-    const topic = 'pss topic'
-    const target = '0f9c'
-    const message = 'hello'
-    await pss.send(BEE_URL, topic, target, message)
-  })
+  it(
+    'should send PSS message',
+    async () => {
+      const topic = 'topic'
+      const message = 'hello'
+
+      const debugUrl = beeDebugUrl()
+      const peers = await connectivity.getPeers(debugUrl)
+      expect(peers.peers.length).toBeGreaterThan(0)
+
+      const target = peers.peers[0].address
+      const response = await pss.send(BEE_URL, topic, target, message)
+
+      expect(response).toEqual(okResponse)
+    },
+    PSS_TIMEOUT,
+  )
+
+  it(
+    'should send and receive PSS message',
+    async done => {
+      const topic = 'topic'
+      const message = 'hello'
+
+      const ws = pss.subscribe(BEE_URL, topic)
+      ws.onmessage = ev => {
+        expect(Buffer.from(ev.data).toString()).toEqual(message)
+        ws.terminate()
+        done()
+      }
+
+      const debugUrl = beeDebugUrl()
+      const addresses = await connectivity.getNodeAddresses(debugUrl)
+      const target = addresses.overlay
+
+      await pss.send(BEE_PEER_URL, topic, target, message)
+    },
+    PSS_TIMEOUT,
+  )
+
+  it(
+    'should send and receive PSS message with public key',
+    async done => {
+      const topic = 'topic'
+      const message = 'hello'
+
+      const ws = pss.subscribe(BEE_URL, topic)
+      ws.onmessage = ev => {
+        expect(Buffer.from(ev.data).toString()).toEqual(message)
+        ws.terminate()
+        done()
+      }
+
+      const debugUrl = beeDebugUrl()
+      const addresses = await connectivity.getNodeAddresses(debugUrl)
+      const target = addresses.overlay
+      const recipient = addresses.pss_public_key
+
+      await pss.send(BEE_PEER_URL, topic, target, message, recipient)
+    },
+    PSS_TIMEOUT,
+  )
 })

--- a/test/modules/pss.spec.ts
+++ b/test/modules/pss.spec.ts
@@ -1,11 +1,9 @@
 import * as pss from '../../src/modules/pss'
 import * as connectivity from '../../src/modules/debug/connectivity'
-import { beeDebugUrl, beePeerUrl, beeUrl, okResponse } from '../utils'
+import { beeDebugUrl, beePeerUrl, beeUrl, okResponse, PSS_TIMEOUT } from '../utils'
 
 const BEE_URL = beeUrl()
 const BEE_PEER_URL = beePeerUrl()
-
-const PSS_TIMEOUT = 60000
 
 // these tests only work when there is at least one peer connected
 describe('modules/pss', () => {
@@ -29,7 +27,7 @@ describe('modules/pss', () => {
 
   it(
     'should send and receive PSS message',
-    done => {
+    async done => {
       const topic = 'send-receive-pss-message'
       const message = 'hello'
 
@@ -42,18 +40,16 @@ describe('modules/pss', () => {
 
       const debugUrl = beeDebugUrl()
 
-      return connectivity.getNodeAddresses(debugUrl).then(addresses => {
-        const target = addresses.overlay
-
-        return pss.send(BEE_PEER_URL, topic, target, message)
-      })
+      const addresses = await connectivity.getNodeAddresses(debugUrl)
+      const target = addresses.overlay
+      await pss.send(BEE_PEER_URL, topic, target, message)
     },
     PSS_TIMEOUT,
   )
 
   it(
     'should send and receive PSS message with public key',
-    done => {
+    async done => {
       const topic = 'send-receive-pss-public-key'
       const message = 'hello'
 
@@ -66,12 +62,10 @@ describe('modules/pss', () => {
 
       const debugUrl = beeDebugUrl()
 
-      return connectivity.getNodeAddresses(debugUrl).then(addresses => {
-        const target = addresses.overlay
-        const recipient = addresses.pss_public_key
-
-        return pss.send(BEE_PEER_URL, topic, target, message, recipient)
-      })
+      const addresses = await connectivity.getNodeAddresses(debugUrl)
+      const target = addresses.overlay
+      const recipient = addresses.pss_public_key
+      await pss.send(BEE_PEER_URL, topic, target, message, recipient)
     },
     PSS_TIMEOUT,
   )

--- a/test/modules/pss.spec.ts
+++ b/test/modules/pss.spec.ts
@@ -4,10 +4,10 @@ import { beeUrl } from '../utils'
 const BEE_URL = beeUrl()
 
 describe('modules/pss', () => {
-  it('should send PSS message', async (done) => {
+  it('should send PSS message', async () => {
     const topic = 'pss topic'
     const target = '0f9c'
     const message = 'hello'
-    const response = await pss.send(BEE_URL, topic, target, message)
+    await pss.send(BEE_URL, topic, target, message)
   })
 })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -53,4 +53,20 @@ export function beeUrl(): string {
   return process.env.BEE_URL || 'http://bee-0.localhost'
 }
 
+export function beePeerUrl(): string {
+  return process.env.BEE_PEER_URL || 'http://bee-1.localhost'
+}
+
+export function beeDebugUrl(url: string = beeUrl()): string {
+  const urlObj = new URL(url)
+  const port = urlObj.port ? parseInt(urlObj.port, 10) + 2 : 1635
+
+  return urlObj.protocol + '//' + urlObj.hostname + ':' + port
+}
+
 export const invalidReference = '0000000000000000000000000000000000000000000000000000000000000000'
+
+export const okResponse = {
+  code: 200,
+  message: 'OK',
+}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -4,7 +4,6 @@ import { Readable } from 'stream'
  * Sleep for N miliseconds
  *
  * @param ms Number of miliseconds to sleep
- * @param args Values to be returned
  */
 export function sleep(ms: number): Promise<void> {
   return new Promise<void>(resolve => setTimeout(() => resolve(), ms))
@@ -49,14 +48,23 @@ export function randomByteArray(length: number, seed = 500): Uint8Array {
   return buf
 }
 
+/**
+ * Returns a url for testing the Bee public API
+ */
 export function beeUrl(): string {
   return process.env.BEE_URL || 'http://bee-0.localhost'
 }
 
+/**
+ * Returns a url of another peer for testing the Bee public API
+ */
 export function beePeerUrl(): string {
   return process.env.BEE_PEER_URL || 'http://bee-1.localhost'
 }
 
+/**
+ * Returns a url for testing the Bee Debug API
+ */
 export function beeDebugUrl(url: string = beeUrl()): string {
   const regexp = /http:\/\/bee-(\d).localhost/
 
@@ -75,3 +83,4 @@ export const okResponse = {
   code: 200,
   message: 'OK',
 }
+export const PSS_TIMEOUT = 60000

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -59,6 +59,7 @@ export function beePeerUrl(): string {
 
 export function beeDebugUrl(url: string = beeUrl()): string {
   const regexp = /http:\/\/bee-(\d).localhost/
+
   if (url.match(regexp)) {
     return url.replace(regexp, 'http://bee-$1-debug.localhost')
   }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,13 +1,13 @@
 import { Readable } from 'stream'
 
 /**
- * Sleep for N miliseconds and return any args past
+ * Sleep for N miliseconds
  *
  * @param ms Number of miliseconds to sleep
  * @param args Values to be returned
  */
-export function sleep<T>(ms: number, ...args: T[]): Promise<T> {
-  return new Promise(resolve => setTimeout(() => resolve(...args), ms))
+export function sleep(ms: number): Promise<void> {
+  return new Promise<void>(resolve => setTimeout(() => resolve(), ms))
 }
 
 export function createReadable(input: string | Uint8Array): Readable {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -58,6 +58,10 @@ export function beePeerUrl(): string {
 }
 
 export function beeDebugUrl(url: string = beeUrl()): string {
+  const regexp = /http:\/\/bee-(\d).localhost/
+  if (url.match(regexp)) {
+    return url.replace(regexp, 'http://bee-$1-debug.localhost')
+  }
   const urlObj = new URL(url)
   const port = urlObj.port ? parseInt(urlObj.port, 10) + 2 : 1635
 


### PR DESCRIPTION
This PR implements the PSS send and subscribe functionality. There is also a `pssReceive` function on the Bee class to simplify the case when you want to receive just one message and it uses `pssSubscribe` internally. The WebSocket interface is not exposed on the public interface because I find it too cumbersome and error-prone to use. Instead a `PssMessageHandler` type is defined for recieving messages and error and a `PssSubscription` type is defined to provide cancel functionality on the subscription.

For this functionality we also need to access the debug API to get access to the overlay address and pssPublicKey. I added a DebugBee class temporarily to support this however I expect that on the long term these will move to a private API and its configuration may effect how we construct the Bee object as well.

The naming in the debug API is a bit inconsistent, I opened an issue about that: https://github.com/ethersphere/bee/issues/1078
