### PR TITLE
feat: chunk API module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import * as pinning from './modules/pinning'
 import * as bytes from './modules/bytes'
 import * as pss from './modules/pss'
 import * as connectivity from './modules/debug/connectivity'
-import {
+import type {
   Tag,
   FileData,
   Reference,
@@ -16,6 +16,7 @@ import {
   Address,
   PssMessageHandler,
   PssSubscription,
+  BeeResponse,
 } from './types'
 import { BeeError } from './utils/error'
 
@@ -174,7 +175,7 @@ export class Bee {
    *
    * @param reference Bee file reference
    */
-  pinFile(reference: Reference): Promise<pinning.Response> {
+  pinFile(reference: Reference): Promise<BeeResponse> {
     return pinning.pinFile(this.url, reference)
   }
 
@@ -183,7 +184,7 @@ export class Bee {
    *
    * @param reference Bee file reference
    */
-  unpinFile(reference: Reference): Promise<pinning.Response> {
+  unpinFile(reference: Reference): Promise<BeeResponse> {
     return pinning.unpinFile(this.url, reference)
   }
 
@@ -192,7 +193,7 @@ export class Bee {
    *
    * @param reference Bee collection reference
    */
-  pinCollection(reference: Reference): Promise<pinning.Response> {
+  pinCollection(reference: Reference): Promise<BeeResponse> {
     return pinning.pinCollection(this.url, reference)
   }
 
@@ -201,7 +202,7 @@ export class Bee {
    *
    * @param reference Bee collection reference
    */
-  unpinCollection(reference: Reference): Promise<pinning.Response> {
+  unpinCollection(reference: Reference): Promise<BeeResponse> {
     return pinning.unpinCollection(this.url, reference)
   }
 
@@ -210,7 +211,7 @@ export class Bee {
    *
    * @param reference Bee data reference
    */
-  pinData(reference: Reference): Promise<pinning.Response> {
+  pinData(reference: Reference): Promise<BeeResponse> {
     return pinning.pinData(this.url, reference)
   }
 
@@ -219,7 +220,7 @@ export class Bee {
    *
    * @param reference Bee data reference
    */
-  unpinData(reference: Reference): Promise<pinning.Response> {
+  unpinData(reference: Reference): Promise<BeeResponse> {
     return pinning.unpinData(this.url, reference)
   }
 
@@ -237,7 +238,7 @@ export class Bee {
     target: AddressPrefix,
     data: string | Uint8Array,
     recipient?: PublicKey,
-  ): Promise<pss.Response> {
+  ): Promise<BeeResponse> {
     return pss.send(this.url, topic, target, data, recipient)
   }
 

--- a/src/modules/chunk.ts
+++ b/src/modules/chunk.ts
@@ -1,0 +1,70 @@
+import type { Readable } from 'stream'
+import type { BeeResponse, UploadOptions } from '../types'
+import { prepareData } from '../utils/data'
+import { extractUploadHeaders } from '../utils/headers'
+import { safeAxios } from '../utils/safeAxios'
+
+const endpoint = '/chunks'
+
+/**
+ * Upload chunk to a Bee node
+ *
+ * The chunk data consists of 8 byte span and up to 4096 bytes of payload data.
+ * The span stores the length of the payload in uint64 little endian encoding.
+ * Upload expects the chuck data to be set accordingly.
+ *
+ * @param url     Bee URL
+ * @param hash    Chunk reference
+ * @param data    Chunk data to be uploaded
+ * @param options Aditional options like tag, encryption, pinning
+ */
+export async function upload(
+  url: string,
+  hash: string,
+  data: Uint8Array,
+  options?: UploadOptions,
+): Promise<BeeResponse> {
+  const response = await safeAxios<BeeResponse>({
+    method: 'post',
+    url: `${url}${endpoint}/${hash}`,
+    data: await prepareData(data),
+    headers: {
+      'content-type': 'application/octet-stream',
+      ...extractUploadHeaders(options),
+    },
+    responseType: 'json',
+  })
+
+  return response.data
+}
+
+/**
+ * Download chunk data as a byte array
+ *
+ * @param url  Bee URL
+ * @param hash Bee content reference
+ *
+ */
+export async function download(url: string, hash: string): Promise<Uint8Array> {
+  const response = await safeAxios<ArrayBuffer>({
+    responseType: 'arraybuffer',
+    url: `${url}${endpoint}/${hash}`,
+  })
+
+  return new Uint8Array(response.data)
+}
+
+/**
+ * Download chunk data as a readable stream
+ *
+ * @param url  Bee URL
+ * @param hash Bee content reference
+ */
+export async function downloadReadable(url: string, hash: string): Promise<Readable> {
+  const response = await safeAxios<Readable>({
+    responseType: 'stream',
+    url: `${url}${endpoint}/${hash}`,
+  })
+
+  return response.data
+}

--- a/src/modules/pinning.ts
+++ b/src/modules/pinning.ts
@@ -132,31 +132,53 @@ export async function getChunkPinningStatus(url: string, hash: string): Promise<
 }
 
 /**
- * Update pinning status of chunk with given reference
+ * Update pin counter of chunk with given reference
  *
- * @param url  Bee URL
- * @param hash Bee data reference
+ * @param url         Bee URL
+ * @param hash        Bee data reference
+ * @param pinCounter  New value of the pin counter
  */
-export async function updateChunkPinningStatus(url: string, hash: string): Promise<PinningStatus> {
+export async function updateChunkPinCounter(url: string, hash: string, pinCounter: number): Promise<PinningStatus> {
   const response = await safeAxios<PinningStatus>({
     method: 'put',
     responseType: 'json',
     url: `${url}${Endpoint.CHUNKS}/${hash}`,
+    data: {
+      pinCounter,
+    },
   })
 
   return response.data
 }
 
 /**
+ * Optional parameters to change listing
+ */
+export interface PinnedChunksOptions {
+  /**
+   * Offset of the items returned.
+   * Maximum value is 2147483647
+   */
+  offset?: number
+  /**
+   * Limits the number of item returned. By default Bee returns 100 items.
+   * Maximum value is 2147483647
+   */
+  limit?: number
+}
+
+/**
  * Get list of pinned chunks
  *
- * @param url Bee URL
+ * @param url     Bee URL
+ * @param options Optional offset and limit of listing
  */
-export async function getPinnedChunks(url: string): Promise<PinnedChunks> {
+export async function getPinnedChunks(url: string, options?: PinnedChunksOptions): Promise<PinnedChunks> {
   const response = await safeAxios<PinnedChunks>({
     method: 'get',
     responseType: 'json',
     url: `${url}${Endpoint.CHUNKS}`,
+    params: options,
   })
 
   return response.data

--- a/src/modules/pinning.ts
+++ b/src/modules/pinning.ts
@@ -1,18 +1,24 @@
+import type { BeeResponse } from '../types'
 import { safeAxios } from '../utils/safeAxios'
 
 enum Endpoint {
   FILE = '/pin/files',
   COLLECTION = '/pin/bzz',
   BYTES = '/pin/bytes',
+  CHUNKS = '/pin/chunks',
 }
 
-export interface Response {
-  message: string
-  code: number
+export interface PinningStatus {
+  address: string
+  pinCounter: number
 }
 
-async function pinRequest(url: string, method: 'post' | 'delete'): Promise<Response> {
-  const response = await safeAxios<Response>({
+export interface PinnedChunks {
+  chunks: PinningStatus[]
+}
+
+async function pinRequest(url: string, method: 'post' | 'delete'): Promise<BeeResponse> {
+  const response = await safeAxios<BeeResponse>({
     method,
     responseType: 'json',
     url,
@@ -21,11 +27,11 @@ async function pinRequest(url: string, method: 'post' | 'delete'): Promise<Respo
   return response.data
 }
 
-function pin(url: string, endpoint: Endpoint, hash: string): Promise<Response> {
+function pin(url: string, endpoint: Endpoint, hash: string): Promise<BeeResponse> {
   return pinRequest(`${url}${endpoint}/${hash}`, 'post')
 }
 
-function unpin(url: string, endpoint: Endpoint, hash: string): Promise<Response> {
+function unpin(url: string, endpoint: Endpoint, hash: string): Promise<BeeResponse> {
   return pinRequest(`${url}${endpoint}/${hash}`, 'delete')
 }
 
@@ -35,7 +41,7 @@ function unpin(url: string, endpoint: Endpoint, hash: string): Promise<Response>
  * @param url  Bee URL
  * @param hash Bee file reference
  */
-export function pinFile(url: string, hash: string): Promise<Response> {
+export function pinFile(url: string, hash: string): Promise<BeeResponse> {
   return pin(url, Endpoint.FILE, hash)
 }
 
@@ -45,7 +51,7 @@ export function pinFile(url: string, hash: string): Promise<Response> {
  * @param url  Bee URL
  * @param hash Bee file reference
  */
-export function unpinFile(url: string, hash: string): Promise<Response> {
+export function unpinFile(url: string, hash: string): Promise<BeeResponse> {
   return unpin(url, Endpoint.FILE, hash)
 }
 
@@ -55,7 +61,7 @@ export function unpinFile(url: string, hash: string): Promise<Response> {
  * @param url  Bee URL
  * @param hash Bee collection reference
  */
-export function pinCollection(url: string, hash: string): Promise<Response> {
+export function pinCollection(url: string, hash: string): Promise<BeeResponse> {
   return pin(url, Endpoint.COLLECTION, hash)
 }
 
@@ -65,7 +71,7 @@ export function pinCollection(url: string, hash: string): Promise<Response> {
  * @param url  Bee URL
  * @param hash Bee collection reference
  */
-export function unpinCollection(url: string, hash: string): Promise<Response> {
+export function unpinCollection(url: string, hash: string): Promise<BeeResponse> {
   return unpin(url, Endpoint.COLLECTION, hash)
 }
 
@@ -75,7 +81,7 @@ export function unpinCollection(url: string, hash: string): Promise<Response> {
  * @param url  Bee URL
  * @param hash Bee data reference
  */
-export function pinData(url: string, hash: string): Promise<Response> {
+export function pinData(url: string, hash: string): Promise<BeeResponse> {
   return pin(url, Endpoint.BYTES, hash)
 }
 
@@ -85,6 +91,73 @@ export function pinData(url: string, hash: string): Promise<Response> {
  * @param url  Bee URL
  * @param hash Bee data reference
  */
-export function unpinData(url: string, hash: string): Promise<Response> {
+export function unpinData(url: string, hash: string): Promise<BeeResponse> {
   return unpin(url, Endpoint.BYTES, hash)
+}
+
+/**
+ * Pin chunks with given reference
+ *
+ * @param url  Bee URL
+ * @param hash Bee data reference
+ */
+export function pinChunk(url: string, hash: string): Promise<BeeResponse> {
+  return pin(url, Endpoint.CHUNKS, hash)
+}
+
+/**
+ * Unpin chunks with given reference
+ *
+ * @param url  Bee URL
+ * @param hash Bee data reference
+ */
+export function unpinChunk(url: string, hash: string): Promise<BeeResponse> {
+  return unpin(url, Endpoint.CHUNKS, hash)
+}
+
+/**
+ * Get pinning status of chunk with given reference
+ *
+ * @param url  Bee URL
+ * @param hash Bee data reference
+ */
+export async function getChunkPinningStatus(url: string, hash: string): Promise<PinningStatus> {
+  const response = await safeAxios<PinningStatus>({
+    method: 'get',
+    responseType: 'json',
+    url: `${url}${Endpoint.CHUNKS}/${hash}`,
+  })
+
+  return response.data
+}
+
+/**
+ * Update pinning status of chunk with given reference
+ *
+ * @param url  Bee URL
+ * @param hash Bee data reference
+ */
+export async function updateChunkPinningStatus(url: string, hash: string): Promise<PinningStatus> {
+  const response = await safeAxios<PinningStatus>({
+    method: 'put',
+    responseType: 'json',
+    url: `${url}${Endpoint.CHUNKS}/${hash}`,
+  })
+
+  return response.data
+}
+
+/**
+ * Get list of pinned chunks
+ *
+ * @param url Bee URL
+ */
+export async function getPinnedChunks(url: string): Promise<PinnedChunks> {
+  const response = await safeAxios<PinnedChunks>({
+    method: 'get',
+    responseType: 'json',
+    url: `${url}${Endpoint.CHUNKS}`,
+  })
+
+  return response.data
 }

--- a/src/modules/pss.ts
+++ b/src/modules/pss.ts
@@ -1,15 +1,10 @@
 import WebSocket from 'isomorphic-ws'
 
-import { PublicKey } from '../types'
+import type { BeeResponse, PublicKey } from '../types'
 import { prepareData } from '../utils/data'
 import { safeAxios } from '../utils/safeAxios'
 
 const endpoint = '/pss'
-
-export interface Response {
-  message: string
-  code: number
-}
 
 /**
  * Send to recipient or target with Postal Service for Swarm
@@ -26,8 +21,8 @@ export async function send(
   target: string,
   data: string | Uint8Array,
   recipient?: PublicKey,
-): Promise<Response> {
-  const response = await safeAxios<Response>({
+): Promise<BeeResponse> {
+  const response = await safeAxios<BeeResponse>({
     method: 'post',
     url: `${url}${endpoint}/send/${topic}/${target.slice(0, 4)}`,
     data: await prepareData(data),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -74,3 +74,8 @@ export interface PssMessageHandler {
   onMessage: (message: Uint8Array, subscription: PssSubscription) => void
   onError: (error: BeeError, subscription: PssSubscription) => void
 }
+
+export interface BeeResponse {
+  message: string
+  code: number
+}

--- a/test/modules/chunk.spec.ts
+++ b/test/modules/chunk.spec.ts
@@ -1,0 +1,25 @@
+import * as chunk from '../../src/modules/chunk'
+import { beeUrl, invalidReference, okResponse } from '../utils'
+
+const BEE_URL = beeUrl()
+
+describe('modules/chunk', () => {
+  it('should store and retrieve data', async () => {
+    const payload = new Uint8Array([1, 2, 3])
+    // span is the payload length encoded as uint64 little endian
+    const span = new Uint8Array([payload.length, 0, 0, 0, 0, 0, 0, 0])
+    const data = new Uint8Array([...span, ...payload])
+    // the hash is hardcoded because we would need the bmt hasher otherwise
+    const hash = 'ca6357a08e317d15ec560fef34e4c45f8f19f01c372aa70f1da72bfa7f1a4338'
+
+    const response = await chunk.upload(BEE_URL, hash, data)
+    expect(response).toEqual(okResponse)
+
+    const downloadedData = await chunk.download(BEE_URL, hash)
+    expect(downloadedData).toEqual(data)
+  })
+
+  it('should catch error', async () => {
+    await expect(chunk.download(BEE_URL, invalidReference)).rejects.toThrow('Internal Server Error')
+  })
+})

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -85,3 +85,10 @@ export const okResponse: BeeResponse = {
   message: 'OK',
 }
 export const PSS_TIMEOUT = 60000
+
+export const testChunkPayload = new Uint8Array([1, 2, 3])
+// span is the payload length encoded as uint64 little endian
+export const testChunkSpan = new Uint8Array([testChunkPayload.length, 0, 0, 0, 0, 0, 0, 0])
+export const testChunkData = new Uint8Array([...testChunkSpan, ...testChunkPayload])
+// the hash is hardcoded because we would need the bmt hasher otherwise
+export const testChunkHash = 'ca6357a08e317d15ec560fef34e4c45f8f19f01c372aa70f1da72bfa7f1a4338'

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,4 +1,5 @@
 import { Readable } from 'stream'
+import type { BeeResponse } from '../src/types'
 
 /**
  * Sleep for N miliseconds
@@ -79,7 +80,7 @@ export function beeDebugUrl(url: string = beeUrl()): string {
 
 export const invalidReference = '0000000000000000000000000000000000000000000000000000000000000000'
 
-export const okResponse = {
+export const okResponse: BeeResponse = {
   code: 200,
   message: 'OK',
 }


### PR DESCRIPTION
This PR implements the endpoints related to chunks (chunk upload, download and pinning). It only adds at the module level because at the `Bee` class level I plan to add higher level functionality (e.g. Chunk interface instead of  `Uint8Array`s).

The upload API is quite strange that it already requires the hash to be calculated in order to be able to upload. Since this functionality was not yet added, I hardcoded some pre-calculated values in the upload and download test.

The chunk pinning API has a few extra functions compared to the other (bytes, fiels, collection) APIs and testing it is a bit difficult with only having hardcoded values because this way the tests affect each other. I plan to change that in the next iteration when we are able to create (pseudo-)random chunks, in this PR the goal of the tests are to provide coverage for the endpoint wrapper functions.