### PR TITLE
fix: raise payment tolerance on tests

### DIFF
--- a/test/bee.sh
+++ b/test/bee.sh
@@ -138,7 +138,8 @@ if [ -z "$QUEEN_CONTAINER_IN_DOCKER" ] || $EPHEMERAL ; then
         --swap-enable=false \
         --debug-api-enable \
         --welcome-message="You have found the queen of the beehive..." \
-        --cors-allowed-origins="*"
+        --cors-allowed-origins="*" \
+        --payment-tolerance 2147483647
 else
     docker start "$QUEEN_CONTAINER_IN_DOCKER"
 fi

--- a/test/bee.sh
+++ b/test/bee.sh
@@ -139,7 +139,7 @@ if [ -z "$QUEEN_CONTAINER_IN_DOCKER" ] || $EPHEMERAL ; then
         --debug-api-enable \
         --welcome-message="You have found the queen of the beehive..." \
         --cors-allowed-origins="*" \
-        --payment-tolerance 2147483647
+        --payment-tolerance=2147483647
 else
     docker start "$QUEEN_CONTAINER_IN_DOCKER"
 fi
@@ -174,7 +174,8 @@ for i in $(seq 1 1 $WORKERS); do
           --swap-enable=false \
           --debug-api-enable \
           --welcome-message="I'm just Bee worker ${i} in the beehive." \
-          --cors-allowed-origins="*"
+          --cors-allowed-origins="*" \
+          --payment-tolerance=2147483647
   else
         docker start "$WORKER_CONTAINER_IN_DOCKER"
   fi


### PR DESCRIPTION
at issue #62 turned out the script which is provided to run local tests in cluster, after a while, run out of the balance.
it fixes that problem by adding the maximum possible amount of payment tolerance value for the `queen` node.