### PR TITLE
fix: remove utf8-encoder package dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11329,11 +11329,6 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
-    "utf8-encoder": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utf8-encoder/-/utf8-encoder-1.0.1.tgz",
-      "integrity": "sha512-vvT5xiEKMbMdACragnFbZLk1gq7ImtyfqzkfMKgDraV0nz90MR7+O23b041zx91UkFueLAuFHDMih8JsiSaoyQ=="
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "isomorphic-ws": "^4.0.1",
     "js-sha3": "^0.8.0",
     "tar-js": "^0.3.0",
-    "utf8-encoder": "^1.0.1",
     "ws": "^7.4.1"
   },
   "devDependencies": {

--- a/src/types/utf8-encoder.d.ts
+++ b/src/types/utf8-encoder.d.ts
@@ -1,4 +1,0 @@
-declare module 'utf8-encoder' {
-  function fromString(s: string): Uint8Array
-  function toString(u: Uint8Array): string
-}

--- a/src/utils/tar.ts
+++ b/src/utils/tar.ts
@@ -1,6 +1,5 @@
 import { Collection } from '../types'
 import Tar from 'tar-js'
-import * as utf8 from 'utf8-encoder'
 
 // this is a workaround type so that we are able to pass in Uint8Arrays
 // as string to `tar.append`
@@ -12,7 +11,7 @@ interface StringLike {
 // converts a string to utf8 Uint8Array and returns it as a string-like
 // object that `tar.append` accepts as path
 function fixUnicodePath(path: string): StringLike {
-  const codes = utf8.fromString(path)
+  const codes = new TextEncoder().encode(path)
 
   return {
     length: codes.length,


### PR DESCRIPTION
I just realized that for fixing the unicode path for uploading an extra dependency was added which is not necessary. This PR removes the `utf8-encoder` package and uses the standard [TextEncoder](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder) API instead.