### PR TITLE
test: increase big upload timeout

### DIFF
--- a/test/modules/collection.spec.ts
+++ b/test/modules/collection.spec.ts
@@ -79,7 +79,7 @@ describe('modules/collection', () => {
     const response = await collection.upload(BEE_URL, directoryStructure)
 
     expect(typeof response).toEqual('string')
-  })
+  }, 20000)
 
   it('should throw error when the upload url is not set', async () => {
     await expect(

--- a/test/modules/file.spec.ts
+++ b/test/modules/file.spec.ts
@@ -58,5 +58,5 @@ describe('modules/file', () => {
     const response = await file.upload(BEE_URL, data)
 
     expect(typeof response).toEqual('string')
-  })
+  }, 20000)
 })


### PR DESCRIPTION
The tests for uploading big files sometimes took longer than the default timeout so I increased the timeouts for these two tests.