### PR TITLE
ci: add node v15 as test target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x, 15.x]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
As per the nodejs release cycle, we should support node v15 as well https://nodejs.org/en/about/releases/