### PR TITLE
feat: balances and consumed endpoint

### DIFF
--- a/src/modules/debug/balance.ts
+++ b/src/modules/debug/balance.ts
@@ -1,0 +1,71 @@
+import { safeAxios } from "../../utils/safeAxios"
+
+const balancesEndpoint = '/balances'
+const consumedEndpoint = '/consumed'
+
+interface PeerBalance {
+  peer: string
+  balance: number
+}
+
+interface BalanceResponse {
+  balances: PeerBalance[]
+}
+
+/**
+ * Get the balances with all known peers including prepaid services
+ *
+ * @param url Bee debug url
+ */
+export async function getAllBalances(url: string): Promise<BalanceResponse> {
+  const response = await safeAxios<BalanceResponse>({
+    url: url + balancesEndpoint,
+    responseType: 'json',
+  })
+
+  return response.data
+}
+
+/**
+ * Get the balances with a specific peer including prepaid services
+ *
+ * @param url     Bee debug url
+ * @param address Swarm address of peer
+ */
+export async function getPeerBalance(url: string, address: string): Promise<PeerBalance> {
+  const response = await safeAxios<PeerBalance>({
+    url: url + `${balancesEndpoint}/${address}`,
+    responseType: 'json',
+  })
+
+  return response.data
+}
+
+/**
+ * Get the past due consumption balances with all known peers
+ *
+ * @param url Bee debug url
+ */
+export async function getPastDueConsumptionBalances(url: string): Promise<BalanceResponse> {
+  const response = await safeAxios<BalanceResponse>({
+    url: url + consumedEndpoint,
+    responseType: 'json',
+  })
+
+  return response.data
+}
+
+/**
+ * Get the past due consumption balance with a specific peer
+ *
+ * @param url     Bee debug url
+ * @param address Swarm address of peer
+ */
+export async function getPastDueConsumptionPeerBalance(url: string, address: string): Promise<PeerBalance> {
+  const response = await safeAxios<PeerBalance>({
+    url: url + `${consumedEndpoint}/${address}`,
+    responseType: 'json',
+  })
+
+  return response.data
+}

--- a/src/modules/debug/balance.ts
+++ b/src/modules/debug/balance.ts
@@ -1,4 +1,4 @@
-import { safeAxios } from "../../utils/safeAxios"
+import { safeAxios } from '../../utils/safeAxios'
 
 const balancesEndpoint = '/balances'
 const consumedEndpoint = '/consumed'

--- a/test/modules/debug/balance.spec.ts
+++ b/test/modules/debug/balance.spec.ts
@@ -1,0 +1,45 @@
+import { beeDebugUrl, beePeerUrl } from "../../utils"
+import * as balance from '../../../src/modules/debug/balance'
+import * as connectivity from '../../../src/modules/debug/connectivity'
+
+// helper function to get the peer overlay address
+async function getPeerOverlay() {
+  const nodeAddresses = await connectivity.getNodeAddresses(beeDebugUrl(beePeerUrl()))
+  return nodeAddresses.overlay
+}
+
+describe('balance', () => {
+  describe('balances', () => {
+    test('Get the balances with all known peers including prepaid services', async () => {
+      const peerOverlay = await getPeerOverlay()
+      const response = await balance.getAllBalances(beeDebugUrl())
+      const peerBalances = response.balances.map(peerBalance => peerBalance.peer)
+
+      expect(peerBalances.includes(peerOverlay)).toBeTruthy()
+    })
+
+    test('Get the balances with all known peers including prepaid services', async () => {
+      const peerOverlay = await getPeerOverlay()
+      const peerBalance = await balance.getPeerBalance(beeDebugUrl(), peerOverlay)
+
+      expect(peerBalance.peer).toEqual(peerOverlay)
+    })
+  })
+
+  describe('consumed', () => {
+    test('Get the past due consumption balances with all known peers', async () => {
+      const peerOverlay = await getPeerOverlay()
+      const response = await balance.getPastDueConsumptionBalances(beeDebugUrl())
+      const peerBalances = response.balances.map(peerBalance => peerBalance.peer)
+
+      expect(peerBalances.includes(peerOverlay)).toBeTruthy()
+    })
+
+    test('Get the past due consumption balance with a specific peer', async () => {
+      const peerOverlay = await getPeerOverlay()
+      const peerBalance = await balance.getPastDueConsumptionPeerBalance(beeDebugUrl(), peerOverlay)
+
+      expect(peerBalance.peer).toEqual(peerOverlay)
+    })
+  })
+})

--- a/test/modules/debug/balance.spec.ts
+++ b/test/modules/debug/balance.spec.ts
@@ -14,6 +14,16 @@ describe('balance', () => {
     test('Get the balances with all known peers including prepaid services', async () => {
       const peerOverlay = await getPeerOverlay()
       const response = await balance.getAllBalances(beeDebugUrl())
+
+      expect(response.balances).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            peer: expect.any(String),
+            balance: expect.any(Number),
+          })
+        ])
+      )
+
       const peerBalances = response.balances.map(peerBalance => peerBalance.peer)
 
       expect(peerBalances.includes(peerOverlay)).toBeTruthy()
@@ -24,6 +34,7 @@ describe('balance', () => {
       const peerBalance = await balance.getPeerBalance(beeDebugUrl(), peerOverlay)
 
       expect(peerBalance.peer).toEqual(peerOverlay)
+      expect(typeof peerBalance.balance).toBe('number')
     })
   })
 
@@ -31,6 +42,16 @@ describe('balance', () => {
     test('Get the past due consumption balances with all known peers', async () => {
       const peerOverlay = await getPeerOverlay()
       const response = await balance.getPastDueConsumptionBalances(beeDebugUrl())
+
+      expect(response.balances).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            peer: expect.any(String),
+            balance: expect.any(Number),
+          })
+        ])
+      )
+
       const peerBalances = response.balances.map(peerBalance => peerBalance.peer)
 
       expect(peerBalances.includes(peerOverlay)).toBeTruthy()
@@ -41,6 +62,7 @@ describe('balance', () => {
       const peerBalance = await balance.getPastDueConsumptionPeerBalance(beeDebugUrl(), peerOverlay)
 
       expect(peerBalance.peer).toEqual(peerOverlay)
+      expect(typeof peerBalance.balance).toBe('number')
     })
   })
 })

--- a/test/modules/debug/balance.spec.ts
+++ b/test/modules/debug/balance.spec.ts
@@ -1,10 +1,11 @@
-import { beeDebugUrl, beePeerUrl } from "../../utils"
+import { beeDebugUrl, beePeerUrl } from '../../utils'
 import * as balance from '../../../src/modules/debug/balance'
 import * as connectivity from '../../../src/modules/debug/connectivity'
 
 // helper function to get the peer overlay address
 async function getPeerOverlay() {
   const nodeAddresses = await connectivity.getNodeAddresses(beeDebugUrl(beePeerUrl()))
+
   return nodeAddresses.overlay
 }
 

--- a/test/modules/debug/balance.spec.ts
+++ b/test/modules/debug/balance.spec.ts
@@ -20,8 +20,8 @@ describe('balance', () => {
           expect.objectContaining({
             peer: expect.any(String),
             balance: expect.any(Number),
-          })
-        ])
+          }),
+        ]),
       )
 
       const peerBalances = response.balances.map(peerBalance => peerBalance.peer)
@@ -48,8 +48,8 @@ describe('balance', () => {
           expect.objectContaining({
             peer: expect.any(String),
             balance: expect.any(Number),
-          })
-        ])
+          }),
+        ]),
       )
 
       const peerBalances = response.balances.map(peerBalance => peerBalance.peer)


### PR DESCRIPTION
Part of #68 

Adds the `/balances` and `/consumed` endpoints described here: https://docs.ethswarm.org/debug-api/#tag/Balance