### PR TITLE
feat: chequebook api

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
     env:
       REPLICA: 5
       BEE_URL: 'http://bee-0.localhost'
+      BEE_CHEQUEBOOK_URL: 'http://bee-0-debug.localhost'
 
     runs-on: ubuntu-latest
 

--- a/src/modules/debug/chequebook.ts
+++ b/src/modules/debug/chequebook.ts
@@ -40,13 +40,13 @@ export async function getChequeubookBalance(url: string): Promise<ChequebookBala
   return response.data
 }
 
-interface CashoutResult {
+export interface CashoutResult {
   recipient: string
   lastPayout: number
   bounced: boolean
 }
 
-interface LastCashoutActionResponse {
+export interface LastCashoutActionResponse {
   peer: string
   chequebook: string
   cumulativePayout: number
@@ -70,7 +70,7 @@ export async function getLastCashoutAction(url: string, peer: string): Promise<L
   return response.data
 }
 
-interface CashoutResponse {
+export interface CashoutResponse {
   transactionHash: string
 }
 
@@ -90,13 +90,13 @@ export async function cashoutLastCheque(url: string, peer: string): Promise<Cash
   return response.data
 }
 
-interface Cheque {
+export interface Cheque {
   beneficiary: string
   chequebook: string
   payout: number
 }
 
-interface LastChequesForPeerResponse {
+export interface LastChequesForPeerResponse {
   peer: string
   lastreceived: Cheque
   lastsent: Cheque
@@ -117,7 +117,7 @@ export async function getLastChequesForPeer(url: string, peer: string): Promise<
   return response.data
 }
 
-interface LastChequesResponse {
+export interface LastChequesResponse {
   lastcheques: LastChequesForPeerResponse[]
 }
 
@@ -135,7 +135,7 @@ export async function getLastCheques(url: string): Promise<LastChequesResponse> 
   return response.data
 }
 
-interface DepositTokensResponse {
+export interface DepositTokensResponse {
   transactionHash: string
 }
 
@@ -156,7 +156,7 @@ export async function depositTokens(url: string, amount: number): Promise<Deposi
   return response.data
 }
 
-interface WithdrawTokensResponse {
+export interface WithdrawTokensResponse {
   transactionHash: string
 }
 

--- a/src/modules/debug/chequebook.ts
+++ b/src/modules/debug/chequebook.ts
@@ -3,7 +3,7 @@ import { safeAxios } from '../../utils/safeAxios'
 const chequebookEndpoint = '/chequebook'
 
 interface CheuqebookAddressResponse {
-  checkbookaddress: string
+  chequebookaddress: string
 }
 
 /**

--- a/src/modules/debug/chequebook.ts
+++ b/src/modules/debug/chequebook.ts
@@ -1,0 +1,177 @@
+import { safeAxios } from "../../utils/safeAxios"
+
+const chequebookEndpoint = '/chequebook'
+
+interface CheuqebookAddressResponse {
+  address: string
+}
+
+/**
+ * Get the address of the chequebook contract used
+ *
+ * @param url Bee debug url
+ */
+export async function getChequebookAddress(url: string): Promise<CheuqebookAddressResponse> {
+  const response = await safeAxios<CheuqebookAddressResponse>({
+    url: url + chequebookEndpoint + '/address',
+    responseType: 'json',
+  })
+
+  return response.data
+}
+
+interface ChequebookBalanceResponse {
+  totalBalance: number
+  availableBalance: number
+}
+
+/**
+ * Get the balance of the chequebook
+ *
+ * @param url Bee debug url
+ */
+export async function getChequeubookBalance(url: string): Promise<ChequebookBalanceResponse> {
+  const response = await safeAxios<ChequebookBalanceResponse>({
+    url: url + chequebookEndpoint + '/balance',
+    responseType: 'json',
+  })
+
+  return response.data
+}
+
+interface CashoutResult {
+  recipient: string
+  lastPayout: number
+  bounced: boolean
+}
+
+interface LastCashoutActionResponse {
+  peer: string
+  chequebook: string
+  cumulativePayout: number
+  beneficiary: string
+  transactionHash: string
+  result: CashoutResult
+}
+
+/**
+ * Get last cashout action for the peer
+ *
+ * @param url   Bee debug url
+ * @param peer  Swarm address of peer
+ */
+export async function getLastCashoutAction(url: string, peer: string): Promise<LastCashoutActionResponse> {
+  const response = await safeAxios<LastCashoutActionResponse>({
+    url: url + chequebookEndpoint + `/cashout/${peer}`,
+    responseType: 'json',
+  })
+
+  return response.data
+}
+
+interface CashoutResponse {
+  transactionHash: string
+}
+
+/**
+ * Cashout the last cheque for the peer
+ *
+ * @param url   Bee debug url
+ * @param peer  Swarm address of peer
+ */
+export async function cashoutLastCheque(url: string, peer: string): Promise<CashoutResponse> {
+  const response = await safeAxios<LastCashoutActionResponse>({
+    method: 'post',
+    url: url + chequebookEndpoint + `/cashout/${peer}`,
+    responseType: 'json',
+  })
+
+  return response.data
+}
+
+interface Cheque {
+  beneficiary: string
+  chequebook: string
+  payout: number
+}
+
+interface LastChequesForPeerResponse {
+  peer: string
+  lastreceived: Cheque
+  lastsent: Cheque
+}
+
+/**
+ * Get last cheques for the peer
+ *
+ * @param url   Bee debug url
+ * @param peer  Swarm address of peer
+ */
+export async function getLastChequesForPeer(url: string, peer: string): Promise<LastChequesForPeerResponse> {
+  const response = await safeAxios<LastChequesForPeerResponse>({
+    url: url + chequebookEndpoint + `/cheque/${peer}`,
+    responseType: 'json',
+  })
+
+  return response.data
+}
+
+interface LastChequesResponse {
+  lastcheques: LastChequesForPeerResponse[]
+}
+
+/**
+ * Get last cheques for all peers
+ *
+ * @param url   Bee debug url
+ */
+export async function getLastCheques(url: string): Promise<LastChequesResponse> {
+  const response = await safeAxios<LastChequesResponse>({
+    url: url + chequebookEndpoint + '/cheque',
+    responseType: 'json',
+  })
+
+  return response.data
+}
+
+interface DepositTokensResponse {
+  transactionHash: string
+}
+
+/**
+ * Deposit tokens from overlay address into chequebook
+ *
+ * @param url     Bee debug url
+ * @param amount  Amount of tokens to deposit
+ */
+export async function depositTokens(url: string, amount: number): Promise<DepositTokensResponse> {
+  const response = await safeAxios<DepositTokensResponse>({
+    method: 'post',
+    url: url + chequebookEndpoint + '/deposit',
+    responseType: 'json',
+    params: { amount },
+  })
+
+  return response.data
+}
+
+interface WithdrawTokensResponse {
+  transactionHash: string
+}
+
+/**
+ * Withdraw tokens from the chequebook to the overlay address
+ *
+ * @param url     Bee debug url
+ * @param amount  Amount of tokens to withdraw
+ */
+export async function withdrawTokens(url: string, amount: number): Promise<WithdrawTokensResponse> {
+  const response = await safeAxios<WithdrawTokensResponse>({
+    method: 'post',
+    url: url + chequebookEndpoint + '/withdraw',
+    responseType: 'json',
+    params: { amount },
+  })
+
+  return response.data
+}

--- a/src/modules/debug/chequebook.ts
+++ b/src/modules/debug/chequebook.ts
@@ -1,4 +1,4 @@
-import { safeAxios } from "../../utils/safeAxios"
+import { safeAxios } from '../../utils/safeAxios'
 
 const chequebookEndpoint = '/chequebook'
 

--- a/src/modules/debug/chequebook.ts
+++ b/src/modules/debug/chequebook.ts
@@ -3,6 +3,7 @@ import { safeAxios } from '../../utils/safeAxios'
 const chequebookEndpoint = '/chequebook'
 
 interface ChequebookAddressResponse {
+  // see this issue regarding the naming https://github.com/ethersphere/bee/issues/1078
   chequebookaddress: string
 }
 

--- a/src/modules/debug/chequebook.ts
+++ b/src/modules/debug/chequebook.ts
@@ -2,7 +2,7 @@ import { safeAxios } from '../../utils/safeAxios'
 
 const chequebookEndpoint = '/chequebook'
 
-interface CheuqebookAddressResponse {
+interface ChequebookAddressResponse {
   chequebookaddress: string
 }
 
@@ -11,8 +11,8 @@ interface CheuqebookAddressResponse {
  *
  * @param url Bee debug url
  */
-export async function getChequebookAddress(url: string): Promise<CheuqebookAddressResponse> {
-  const response = await safeAxios<CheuqebookAddressResponse>({
+export async function getChequebookAddress(url: string): Promise<ChequebookAddressResponse> {
+  const response = await safeAxios<ChequebookAddressResponse>({
     url: url + chequebookEndpoint + '/address',
     responseType: 'json',
   })

--- a/src/modules/debug/chequebook.ts
+++ b/src/modules/debug/chequebook.ts
@@ -3,7 +3,7 @@ import { safeAxios } from '../../utils/safeAxios'
 const chequebookEndpoint = '/chequebook'
 
 interface CheuqebookAddressResponse {
-  address: string
+  checkbookaddress: string
 }
 
 /**

--- a/test/modules/debug/chequebook.spec.ts
+++ b/test/modules/debug/chequebook.spec.ts
@@ -6,6 +6,10 @@ describe('chequebook', () => {
   test('address', async () => {
     const response = await getChequebookAddress(beeDebugUrl())
 
+    /* eslint-disable no-console */
+    console.debug({ response })
+    /* eslint-enable no-console */
+
     expect(isHexString(response.address)).toBeTruthy()
   })
 

--- a/test/modules/debug/chequebook.spec.ts
+++ b/test/modules/debug/chequebook.spec.ts
@@ -1,0 +1,18 @@
+import { getChequebookAddress, getChequeubookBalance } from "../../../src/modules/debug/chequebook"
+import { isHexString } from "../../../src/utils/hex"
+import { beeDebugUrl } from "../../utils"
+
+describe('chequebook', () => {
+  test('address', async () => {
+    const response = await getChequebookAddress(beeDebugUrl())
+
+    expect(isHexString(response.address)).toBeTruthy()
+  })
+
+  test('balance', async () => {
+    const response = await getChequeubookBalance(beeDebugUrl())
+
+    expect(typeof response.availableBalance).toBe('number')
+    expect(typeof response.totalBalance).toBe('number')
+  })
+})

--- a/test/modules/debug/chequebook.spec.ts
+++ b/test/modules/debug/chequebook.spec.ts
@@ -6,11 +6,7 @@ describe('chequebook', () => {
   test('address', async () => {
     const response = await getChequebookAddress(beeDebugUrl())
 
-    /* eslint-disable no-console */
-    console.debug({ response })
-    /* eslint-enable no-console */
-
-    expect(isHexString(response.checkbookaddress)).toBeTruthy()
+    expect(isHexString(response.chequebookaddress)).toBeTruthy()
   })
 
   test('balance', async () => {

--- a/test/modules/debug/chequebook.spec.ts
+++ b/test/modules/debug/chequebook.spec.ts
@@ -1,18 +1,44 @@
-import { getChequebookAddress, getChequeubookBalance } from '../../../src/modules/debug/chequebook'
+import { depositTokens, getChequebookAddress, getChequeubookBalance, getLastCheques, withdrawTokens } from '../../../src/modules/debug/chequebook'
 import { isHexString } from '../../../src/utils/hex'
-import { beeDebugUrl } from '../../utils'
+import { beeChequebookUrl, sleep } from '../../utils'
 
-describe('chequebook', () => {
-  test('address', async () => {
-    const response = await getChequebookAddress(beeDebugUrl())
+const url = beeChequebookUrl()
 
-    expect(isHexString(response.chequebookaddress)).toBeTruthy()
+if (url) {
+  describe('swap enabled chequebook', () => {
+    test('address', async () => {
+      const response = await getChequebookAddress(url)
+
+      expect(isHexString(response.chequebookaddress)).toBeTruthy()
+    })
+
+    test('balance', async () => {
+      const response = await getChequeubookBalance(url)
+
+      expect(typeof response.availableBalance).toBe('number')
+      expect(typeof response.totalBalance).toBe('number')
+    })
+
+    const TRANSACTION_TIMEOUT = 20 * 1000
+
+    test('withdraw and deposit', async () => {
+      const withdrawResponse = await withdrawTokens(url, 10)
+      expect(typeof withdrawResponse.transactionHash).toBe('string')
+
+      // TODO avoid sleep in tests
+      await sleep(TRANSACTION_TIMEOUT)
+
+      const depositResponse = await depositTokens(url, 10)
+
+      expect(typeof depositResponse.transactionHash).toBe('string')
+    }, 2 * TRANSACTION_TIMEOUT)
+
+    test('get last cheques for all peers', async () => {
+      const response = await getLastCheques(url)
+
+      expect(Array.isArray(response.lastcheques)).toBeTruthy()
+    })
   })
-
-  test('balance', async () => {
-    const response = await getChequeubookBalance(beeDebugUrl())
-
-    expect(typeof response.availableBalance).toBe('number')
-    expect(typeof response.totalBalance).toBe('number')
-  })
-})
+} else {
+  test('swap disabled chequebook', () => {})
+}

--- a/test/modules/debug/chequebook.spec.ts
+++ b/test/modules/debug/chequebook.spec.ts
@@ -34,6 +34,7 @@ if (url) {
         expect(typeof withdrawResponse.transactionHash).toBe('string')
 
         // TODO avoid sleep in tests
+        // See https://github.com/ethersphere/bee/issues/1191
         await sleep(TRANSACTION_TIMEOUT)
 
         const depositResponse = await depositTokens(url, 10)
@@ -50,5 +51,12 @@ if (url) {
     })
   })
 } else {
-  test('swap disabled chequebook')
+  test('swap disabled chequebook', () => {
+    // eslint-disable-next-line no-console
+    console.log(`
+      Chequebook tests are disabled because BEE_CHEQUEBOOK_URL is not set.
+      If you want to test chequebook functionality set the environment
+      variable to point to a Bee node with swap-enable.
+    `)
+  })
 }

--- a/test/modules/debug/chequebook.spec.ts
+++ b/test/modules/debug/chequebook.spec.ts
@@ -1,4 +1,10 @@
-import { depositTokens, getChequebookAddress, getChequeubookBalance, getLastCheques, withdrawTokens } from '../../../src/modules/debug/chequebook'
+import {
+  depositTokens,
+  getChequebookAddress,
+  getChequeubookBalance,
+  getLastCheques,
+  withdrawTokens,
+} from '../../../src/modules/debug/chequebook'
 import { isHexString } from '../../../src/utils/hex'
 import { beeChequebookUrl, sleep } from '../../utils'
 
@@ -21,17 +27,21 @@ if (url) {
 
     const TRANSACTION_TIMEOUT = 20 * 1000
 
-    test('withdraw and deposit', async () => {
-      const withdrawResponse = await withdrawTokens(url, 10)
-      expect(typeof withdrawResponse.transactionHash).toBe('string')
+    test(
+      'withdraw and deposit',
+      async () => {
+        const withdrawResponse = await withdrawTokens(url, 10)
+        expect(typeof withdrawResponse.transactionHash).toBe('string')
 
-      // TODO avoid sleep in tests
-      await sleep(TRANSACTION_TIMEOUT)
+        // TODO avoid sleep in tests
+        await sleep(TRANSACTION_TIMEOUT)
 
-      const depositResponse = await depositTokens(url, 10)
+        const depositResponse = await depositTokens(url, 10)
 
-      expect(typeof depositResponse.transactionHash).toBe('string')
-    }, 2 * TRANSACTION_TIMEOUT)
+        expect(typeof depositResponse.transactionHash).toBe('string')
+      },
+      2 * TRANSACTION_TIMEOUT,
+    )
 
     test('get last cheques for all peers', async () => {
       const response = await getLastCheques(url)
@@ -40,5 +50,5 @@ if (url) {
     })
   })
 } else {
-  test('swap disabled chequebook', () => {})
+  test('swap disabled chequebook')
 }

--- a/test/modules/debug/chequebook.spec.ts
+++ b/test/modules/debug/chequebook.spec.ts
@@ -10,7 +10,7 @@ describe('chequebook', () => {
     console.debug({ response })
     /* eslint-enable no-console */
 
-    expect(isHexString(response.address)).toBeTruthy()
+    expect(isHexString(response.checkbookaddress)).toBeTruthy()
   })
 
   test('balance', async () => {

--- a/test/modules/debug/chequebook.spec.ts
+++ b/test/modules/debug/chequebook.spec.ts
@@ -1,6 +1,6 @@
-import { getChequebookAddress, getChequeubookBalance } from "../../../src/modules/debug/chequebook"
-import { isHexString } from "../../../src/utils/hex"
-import { beeDebugUrl } from "../../utils"
+import { getChequebookAddress, getChequeubookBalance } from '../../../src/modules/debug/chequebook'
+import { isHexString } from '../../../src/utils/hex'
+import { beeDebugUrl } from '../../utils'
 
 describe('chequebook', () => {
   test('address', async () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,6 +1,7 @@
 import { Readable } from 'stream'
 import type { BeeResponse } from '../src/types'
 import { HexString } from '../src/utils/hex'
+import * as connectivity from '../src/modules/debug/connectivity'
 
 /**
  * Sleep for N miliseconds
@@ -64,6 +65,10 @@ export function beePeerUrl(): string {
   return process.env.BEE_PEER_URL || 'http://bee-1.localhost'
 }
 
+export function beeChequebookUrl(): string {
+  return process.env.BEE_CHEQUEBOOK_URL || ''
+}
+
 /**
  * Returns a url for testing the Bee Debug API
  */
@@ -98,4 +103,10 @@ export const testIdentity = {
   privateKey: '0x634fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd' as HexString,
   publicKey: '0x03c32bb011339667a487b6c1c35061f15f7edc36aa9a0f8648aba07a4b8bd741b4' as HexString,
   address: '0x8d3766440f0d7b949a5e32995d09619a7f86e632' as HexString,
+}
+
+export async function getPeerOverlay() {
+  const nodeAddresses = await connectivity.getNodeAddresses(beeDebugUrl(beePeerUrl()))
+
+  return nodeAddresses.overlay
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,7 +1,6 @@
 import { Readable } from 'stream'
 import type { BeeResponse } from '../src/types'
 import { HexString } from '../src/utils/hex'
-import * as connectivity from '../src/modules/debug/connectivity'
 
 /**
  * Sleep for N miliseconds
@@ -103,10 +102,4 @@ export const testIdentity = {
   privateKey: '0x634fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd' as HexString,
   publicKey: '0x03c32bb011339667a487b6c1c35061f15f7edc36aa9a0f8648aba07a4b8bd741b4' as HexString,
   address: '0x8d3766440f0d7b949a5e32995d09619a7f86e632' as HexString,
-}
-
-export async function getPeerOverlay() {
-  const nodeAddresses = await connectivity.getNodeAddresses(beeDebugUrl(beePeerUrl()))
-
-  return nodeAddresses.overlay
 }

--- a/test/utils/hex.spec.ts
+++ b/test/utils/hex.spec.ts
@@ -41,6 +41,12 @@ describe('hex', () => {
 
       expect(result).toBeFalsy()
     })
+    test('chequebookaddress', () => {
+      const input = '0x20d7855b548C71b69dA434D46187C336BDcef00F'
+      const result = isHexString(input)
+
+      expect(result).toBeTruthy()
+    })
   })
 
   const testBytes = new Uint8Array([


### PR DESCRIPTION
Part of #68

This PR provides the wrapper functions around the chequebook endpoints. Not all of them have tests because it is not trivial to create the conditions required because of the stateful nature of the functionality.

Also it's not trivial to run the tests locally because they require at least one Bee node running with `swap-enable` set to true and our test runner script currently doesn't do that. The chequebook tests now check if the `BEE_CHEQUEBOOK_URL` environment variable is set and if it's not then those tests are skipped and a message is printed to the console informing about the situation. This environment variable is set when the tests are running on github because there the test runners have `swap-enable` set.

Please note that this functionality is not yet exposed on the Bee class. I plan to implement the [`settlements`](https://docs.ethswarm.org/debug-api/#tag/Settlements) endpoint functions in a different PR, then do the integration of the debug endpoints together (which is related to #59) in another PR.

See also #96 and #98