### PR TITLE
refactor: rename BEE_CHEQUEBOOK_URL to BEE_TEST_CHEQUEBOOK

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     env:
       REPLICA: 5
       BEE_URL: 'http://bee-0.localhost'
-      BEE_CHEQUEBOOK_URL: 'http://bee-0-debug.localhost'
+      BEE_TEST_CHEQUEBOOK: 'test'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     env:
       REPLICA: 5
       BEE_URL: 'http://bee-0.localhost'
-      BEE_TEST_CHEQUEBOOK: 'test'
+      BEE_TEST_CHEQUEBOOK: true
 
     runs-on: ubuntu-latest
 

--- a/test/modules/debug/chequebook.spec.ts
+++ b/test/modules/debug/chequebook.spec.ts
@@ -6,20 +6,18 @@ import {
   withdrawTokens,
 } from '../../../src/modules/debug/chequebook'
 import { isHexString } from '../../../src/utils/hex'
-import { beeChequebookUrl, sleep } from '../../utils'
+import { beeDebugUrl, sleep } from '../../utils'
 
-const url = beeChequebookUrl()
-
-if (url) {
+if (process.env.BEE_TEST_CHEQUEBOOK) {
   describe('swap enabled chequebook', () => {
     test('address', async () => {
-      const response = await getChequebookAddress(url)
+      const response = await getChequebookAddress(beeDebugUrl())
 
       expect(isHexString(response.chequebookaddress)).toBeTruthy()
     })
 
     test('balance', async () => {
-      const response = await getChequeubookBalance(url)
+      const response = await getChequeubookBalance(beeDebugUrl())
 
       expect(typeof response.availableBalance).toBe('number')
       expect(typeof response.totalBalance).toBe('number')
@@ -30,14 +28,14 @@ if (url) {
     test(
       'withdraw and deposit',
       async () => {
-        const withdrawResponse = await withdrawTokens(url, 10)
+        const withdrawResponse = await withdrawTokens(beeDebugUrl(), 10)
         expect(typeof withdrawResponse.transactionHash).toBe('string')
 
         // TODO avoid sleep in tests
         // See https://github.com/ethersphere/bee/issues/1191
         await sleep(TRANSACTION_TIMEOUT)
 
-        const depositResponse = await depositTokens(url, 10)
+        const depositResponse = await depositTokens(beeDebugUrl(), 10)
 
         expect(typeof depositResponse.transactionHash).toBe('string')
       },
@@ -45,7 +43,7 @@ if (url) {
     )
 
     test('get last cheques for all peers', async () => {
-      const response = await getLastCheques(url)
+      const response = await getLastCheques(beeDebugUrl())
 
       expect(Array.isArray(response.lastcheques)).toBeTruthy()
     })
@@ -54,9 +52,7 @@ if (url) {
   test('swap disabled chequebook', () => {
     // eslint-disable-next-line no-console
     console.log(`
-      Chequebook tests are disabled because BEE_CHEQUEBOOK_URL is not set.
-      If you want to test chequebook functionality set the environment
-      variable to point to a Bee node with swap-enable.
+      Chequebook tests are disabled because BEE_TEST_CHEQUEBOOK environment variable is not set.
     `)
   })
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -64,10 +64,6 @@ export function beePeerUrl(): string {
   return process.env.BEE_PEER_URL || 'http://bee-1.localhost'
 }
 
-export function beeChequebookUrl(): string {
-  return process.env.BEE_CHEQUEBOOK_URL || ''
-}
-
 /**
  * Returns a url for testing the Bee Debug API
  */


### PR DESCRIPTION
Before the environment variable had to set to a url of a node with `swap-enable`. Now we just check if the `BEE_TEST_CHEQUEBOOK` environment variable is set or not and run the tests on the debug url.