### PR TITLE
refactor: library import

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 ### npm
 
 ```sh
-> npm install @ethersphere/bee-js
+> npm install --save @ethersphere/bee-js
 ```
 
 ### Use in Node.js
@@ -49,7 +49,7 @@ var BeeJs = require("@ethersphere/bee-js");
 
 ### Use in a browser Using a script tag
 
-Loading this module through a script tag will make the `Bee` object available in the global namespace.
+Loading this module through a script tag will make the `BeeJs` object available in the global namespace.
 
 ```html
 <script src="https://unpkg.com/@ethersphere/bee-js/dist/index.min.js"></script>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 ### npm
 
 ```sh
-> npm install --save @ethersphere/bee-js
+> npm install @ethersphere/bee-js --save
 ```
 
 ### Use in Node.js

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@
 ### Use in Node.js
 
 ```js
-var Bee = require("@ethersphere/bee-js");
+var BeeJs = require("@ethersphere/bee-js");
 ```
 
 ### Use in a browser with browserify, webpack or any other bundler
 
 ```js
-var Bee = require("@ethersphere/bee-js");
+var BeeJs = require("@ethersphere/bee-js");
 ```
 
 ### Use in a browser Using a script tag
@@ -58,7 +58,7 @@ Loading this module through a script tag will make the `Bee` object available in
 ## Usage
 
 ```js
-import Bee from "@ethersphere/bee-js"; // Connect to a node const
+import { Bee } from "@ethersphere/bee-js"; // Connect to a node const
 
 bee = new Bee("http://localhost:1633");
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ var BeeJs = require("@ethersphere/bee-js");
 Loading this module through a script tag will make the `BeeJs` object available in the global namespace.
 
 ```html
-<script src="https://unpkg.com/@ethersphere/bee-js/dist/index.min.js"></script>
+<script src="https://unpkg.com/@ethersphere/bee-js/dist/index.browser.min.js"></script>
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -34,10 +34,9 @@
     "compile:node": "webpack --progress --env target=node",
     "compile:types": "tsc --project tsconfig.d.json",
     "compile:browser": "webpack --progress --env target=web",
-    "compile:window": "webpack --progress --env target=web --env globalWindow=true",
     "docs": "rimraf docs && typedoc",
     "test": "npm run test:node && npm run test:browser",
-    "test:browser": "npm run compile:window && jest --config=jest.config.ts --selectProjects=dom",
+    "test:browser": "npm run compile:browser && jest --config=jest.config.ts --selectProjects=dom",
     "test:node": "jest --config=jest.config.ts --selectProjects=node",
     "lint": "eslint --fix \"src/**/*.ts\" \"test/**/*.ts\" && prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:check": "eslint \"src/**/*.ts\" \"test/**/*.ts\" && prettier --check \"src/**/*.ts\" \"test/**/*.ts\""

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "scripts": {
-    "prepare": "rimraf dist && npm run compile:types && npm run compile:browser && npm run compile:node",
+    "prepare": "rimraf dist && npm run compile:types && npm run compile:browser --env mode=production && npm run compile:node --env mode=production",
     "compile:node": "webpack --progress --env target=node",
     "compile:types": "tsc --project tsconfig.d.json",
     "compile:browser": "webpack --progress --env target=web",

--- a/src/index.ts
+++ b/src/index.ts
@@ -493,4 +493,3 @@ export class BeeDebug {
     return settlements.getAllSettlements(this.url)
   }
 }
-export default Bee

--- a/test/bee-class.spec.ts
+++ b/test/bee-class.spec.ts
@@ -1,4 +1,4 @@
-import Bee, { BeeDebug } from '../src'
+import { Bee, BeeDebug } from '../src'
 import { REFERENCE_LENGTH } from '../src/types'
 import { beeDebugUrl, beePeerUrl, beeUrl, okResponse, PSS_TIMEOUT } from './utils'
 

--- a/test/testpage/.gitignore
+++ b/test/testpage/.gitignore
@@ -1,3 +1,0 @@
-# bee client which is built into the browser's window object for browser tests
-index.browser.global.js
-index.browser.global.js.map

--- a/test/testpage/testpage.html
+++ b/test/testpage/testpage.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <title>BeeJS testing page - Upload</title>
   <!-- Should be retrieved after compilation -> npm run compile:window -->
-  <script src="index.browser.global.js"></script>
+  <script src="../../dist/index.browser.js"></script>
 </head>
 
 <body>

--- a/test/testpage/testpage.html
+++ b/test/testpage/testpage.html
@@ -4,7 +4,6 @@
 <head>
   <meta charset="utf-8">
   <title>BeeJS testing page - Upload</title>
-  <!-- Should be retrieved after compilation -> npm run compile:window -->
   <script src="../../dist/index.browser.js"></script>
 </head>
 

--- a/test/testpage/testpage.ts
+++ b/test/testpage/testpage.ts
@@ -1,5 +1,0 @@
-import { Bee } from '../../src'
-
-window.beeFactory = (...params: ConstructorParameters<typeof Bee>) => new Bee(...params)
-
-window.bee = new Bee(__BEE_URL__)

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -8,7 +8,6 @@ import { getBrowserPathMapping } from './jest.config'
 
 interface WebpackEnvParams {
   target: 'web' | 'node'
-  globalWindow: boolean
   debug: boolean
   mode: 'production' | 'development'
   fileName: string
@@ -16,15 +15,12 @@ interface WebpackEnvParams {
 
 const base = async (env?: Partial<WebpackEnvParams>): Promise<Configuration> => {
   const isProduction = env?.mode === 'production'
-  const isWindow = env?.globalWindow
   const isBrowser = env?.target === 'web'
   const filename =
     env?.fileName ||
-    ['index', isBrowser ? '.browser' : null, isWindow ? '.global' : null, isProduction ? '.min' : null, '.js']
-      .filter(Boolean)
-      .join('')
-  const entry = isWindow ? Path.resolve(__dirname, 'test', 'testpage', 'testpage') : Path.resolve(__dirname, 'src')
-  const path = isWindow ? Path.resolve(__dirname, 'test', 'testpage') : Path.resolve(__dirname, 'dist')
+    ['index', isBrowser ? '.browser' : null, isProduction ? '.min' : null, '.js'].filter(Boolean).join('')
+  const entry = Path.resolve(__dirname, 'src')
+  const path = Path.resolve(__dirname, 'dist')
   const target = env?.target || 'web' // 'node' or 'web'
   const plugins: WebpackPluginInstance[] = [
     new DefinePlugin({
@@ -49,14 +45,6 @@ const base = async (env?: Partial<WebpackEnvParams>): Promise<Configuration> => 
       const browserReference: string = browserModuleMapping[nodeReference]
       plugins.push(new NormalModuleReplacementPlugin(new RegExp(`^${nodeReference}$`), browserReference))
     }
-  }
-
-  if (isWindow) {
-    plugins.push(
-      new DefinePlugin({
-        __BEE_URL__: JSON.stringify(process.env.BEE_URL || 'http://localhost:1633'),
-      }),
-    )
   }
 
   return {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -68,7 +68,7 @@ const base = async (env?: Partial<WebpackEnvParams>): Promise<Configuration> => 
       path,
       filename,
       sourceMapFilename: filename + '.map',
-      library: PackageJson.name,
+      library: 'BeeJs',
       libraryTarget: 'umd',
       globalObject: 'this',
     },


### PR DESCRIPTION
* Remove default `Bee` class export
* Rename library name from `@ethersphere/bee-js` to `BeeJs`.
* Update README with correct library usage examples.
* Simplify browser tests, remove its specific build

Fixes: #109 #99 