### PR TITLE
refactor: change bee url env

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,8 @@ jobs:
   node-tests:
     env:
       REPLICA: 5
-      BEE_URL: 'http://bee-0.localhost'
+      BEE_API_URL: 'http://bee-0.localhost'
+      BEE_PEER_API_URL: 'http://bee-1.localhost'
       BEE_TEST_CHEQUEBOOK: true
 
     runs-on: ubuntu-latest

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,8 @@
         "request": "launch",
           "env": {
               "NODE_ENV": "development",
-              "BEE_URL": "http://localhost:1633"
+              "BEE_API_URL": "http://localhost:1633",
+              "BEE_PEER_API_URL": "http://localhost:11633"
           }
       },
 
@@ -19,7 +20,8 @@
         "request": "launch",
         "env": {
             "NODE_ENV": "development",
-            "BEE_URL": "http://localhost:1633"
+            "BEE_API_URL": "http://localhost:1633",
+            "BEE_PEER_API_URL": "http://localhost:11633"
         },
         "args": [
           "--runInBand",

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ The tests run in both context: node and dom with Jest.
 
 To run the test, you need to have a Bee cluster running locally. To create a cluster, please consult the readme of [@ethersphere/bee-local](https://github.com/ethersphere/bee-local).
 
-By default, tests are run against local bee node 0 - `http://bee-0.localhost`. You can change it by setting environment variable `BEE_URL`.
+By default, tests are run against local bee node 0 - `http://bee-0.localhost`. You can change it by setting environment variable `BEE_API_URL`.
+In order to run tests which require one more node, you need to define `BEE_PEER_API_URL` as well. Its default value `http://bee-1.localhost`
 
 In Visual Studio environment, the tests have been set up to run against your local bee node on `http://localhost:1633`
 To run Jest tests, choose the `vscode-jest-tests` CI job under the Run tab.

--- a/test/bee-class.browser.spec.ts
+++ b/test/bee-class.browser.spec.ts
@@ -1,5 +1,6 @@
 import { join } from 'path'
 import { beeUrl, commonMatchers } from './utils'
+import '../src'
 
 commonMatchers()
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -89,14 +89,14 @@ export function randomByteArray(length: number, seed = 500): Uint8Array {
  * Returns a url for testing the Bee public API
  */
 export function beeUrl(): string {
-  return process.env.BEE_URL || 'http://bee-0.localhost'
+  return process.env.BEE_API_URL || 'http://bee-0.localhost'
 }
 
 /**
  * Returns a url of another peer for testing the Bee public API
  */
 export function beePeerUrl(): string {
-  return process.env.BEE_PEER_URL || 'http://bee-1.localhost'
+  return process.env.BEE_PEER_API_URL || 'http://bee-1.localhost'
 }
 
 /**


### PR DESCRIPTION
### Description
* change `BEE_URL` to `BEE_API_URL` as it represents the API endpoint of the Bee client.
* change `BEE_PEER_URL` to `BEE_PEER_API_URL`

#### Other refactor ideas **for an other refactor branch**
* should be refactored the debug url handling (introduce `BEE_DEBUG_URL` or something similar),
* also seems a good idea to change default fallback values of these URL variables to a more straightforward one (e.g. `http://localhost:1633` on `BEE_API_URL` and `http://localhost:11633` on `BEE_PEER_API_URL`