### PR TITLE
feat: axios options

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,7 +73,7 @@ module.exports = {
           requireLast: true,
         },
         singleline: {
-          delimiter: 'comma',
+          delimiter: 'semi',
           requireLast: false,
         },
       },

--- a/src/bee.ts
+++ b/src/bee.ts
@@ -56,6 +56,7 @@ export class Bee {
    * Download data as a readable stream
    *
    * @param reference Bee data reference
+   * @param axiosOptions optional - alter default options of axios HTTP client
    */
   downloadReadableData(reference: Reference, axiosOptions?: AxiosRequestConfig): Promise<Readable> {
     return bytes.downloadReadable(this.url, reference, axiosOptions)
@@ -155,6 +156,7 @@ export class Bee {
    *
    * @param reference Bee collection reference
    * @param path Path of the requested file in the collection
+   * @param axiosOptions optional - alter default options of axios HTTP client
    *
    * @returns file in readable stream with metadata
    */

--- a/src/bee.ts
+++ b/src/bee.ts
@@ -21,6 +21,7 @@ import type {
 import { BeeError } from './utils/error'
 import { prepareWebsocketData } from './utils/data'
 import { fileArrayBuffer, isFile } from './utils/file'
+import { AxiosRequestConfig } from 'axios'
 
 /**
  * The Bee class provides a way of interacting with the Bee APIs based on the provided url
@@ -56,8 +57,8 @@ export class Bee {
    *
    * @param reference Bee data reference
    */
-  downloadReadableData(reference: Reference): Promise<Readable> {
-    return bytes.downloadReadable(this.url, reference)
+  downloadReadableData(reference: Reference, axiosOptions?: AxiosRequestConfig): Promise<Readable> {
+    return bytes.downloadReadable(this.url, reference, axiosOptions)
   }
 
   /**
@@ -157,8 +158,12 @@ export class Bee {
    *
    * @returns file in readable stream with metadata
    */
-  downloadReadableFileFromCollection(reference: Reference, path = ''): Promise<FileData<Readable>> {
-    return collection.downloadReadable(this.url, reference, path)
+  downloadReadableFileFromCollection(
+    reference: Reference,
+    path = '',
+    axiosOptions?: AxiosRequestConfig,
+  ): Promise<FileData<Readable>> {
+    return collection.downloadReadable(this.url, reference, path, axiosOptions)
   }
 
   /**

--- a/src/modules/bytes.ts
+++ b/src/modules/bytes.ts
@@ -50,6 +50,7 @@ export async function download(url: string, hash: string): Promise<Uint8Array> {
  *
  * @param url  Bee URL
  * @param hash Bee content reference
+ * @param axiosOptions optional - alter default options of axios HTTP client
  */
 export async function downloadReadable(
   url: string,

--- a/src/modules/bytes.ts
+++ b/src/modules/bytes.ts
@@ -23,6 +23,7 @@ export async function upload(url: string, data: string | Uint8Array, options?: U
       ...extractUploadHeaders(options),
     },
     responseType: 'json',
+    ...options?.axiosOptions,
   })
 
   return response.data.reference

--- a/src/modules/bytes.ts
+++ b/src/modules/bytes.ts
@@ -1,3 +1,4 @@
+import type { AxiosRequestConfig } from 'axios'
 import type { Readable } from 'stream'
 import { UploadOptions } from '../types'
 import { prepareData } from '../utils/data'
@@ -50,8 +51,14 @@ export async function download(url: string, hash: string): Promise<Uint8Array> {
  * @param url  Bee URL
  * @param hash Bee content reference
  */
-export async function downloadReadable(url: string, hash: string): Promise<Readable> {
+export async function downloadReadable(
+  url: string,
+  hash: string,
+  axiosOptions?: AxiosRequestConfig,
+): Promise<Readable> {
   const response = await safeAxios<Readable>({
+    ...axiosOptions,
+    method: 'GET',
     responseType: 'stream',
     url: `${url}${endpoint}/${hash}`,
   })

--- a/src/modules/bytes.ts
+++ b/src/modules/bytes.ts
@@ -15,6 +15,7 @@ const endpoint = '/bytes'
  */
 export async function upload(url: string, data: string | Uint8Array, options?: UploadOptions): Promise<string> {
   const response = await safeAxios<{ reference: string }>({
+    ...options?.axiosOptions,
     method: 'post',
     url: url + endpoint,
     data: await prepareData(data),
@@ -23,7 +24,6 @@ export async function upload(url: string, data: string | Uint8Array, options?: U
       ...extractUploadHeaders(options),
     },
     responseType: 'json',
-    ...options?.axiosOptions,
   })
 
   return response.data.reference

--- a/src/modules/chunk.ts
+++ b/src/modules/chunk.ts
@@ -55,6 +55,7 @@ export async function download(url: string, hash: string): Promise<Uint8Array> {
  *
  * @param url  Bee URL
  * @param hash Bee content reference
+ * @param axiosOptions optional - alter default options of axios HTTP client
  */
 export async function downloadReadable(url: string, hash: string, axiosOptions: AxiosRequestConfig): Promise<Readable> {
   const response = await safeAxios<Readable>({

--- a/src/modules/chunk.ts
+++ b/src/modules/chunk.ts
@@ -1,3 +1,4 @@
+import type { AxiosRequestConfig } from 'axios'
 import type { Readable } from 'stream'
 import type { ReferenceResponse, UploadOptions } from '../types'
 import { extractUploadHeaders } from '../utils/headers'
@@ -55,8 +56,10 @@ export async function download(url: string, hash: string): Promise<Uint8Array> {
  * @param url  Bee URL
  * @param hash Bee content reference
  */
-export async function downloadReadable(url: string, hash: string): Promise<Readable> {
+export async function downloadReadable(url: string, hash: string, axiosOptions: AxiosRequestConfig): Promise<Readable> {
   const response = await safeAxios<Readable>({
+    ...axiosOptions,
+    method: 'GET',
     responseType: 'stream',
     url: `${url}${endpoint}/${hash}`,
   })

--- a/src/modules/chunk.ts
+++ b/src/modules/chunk.ts
@@ -19,6 +19,7 @@ const endpoint = '/chunks'
  */
 export async function upload(url: string, data: Uint8Array, options?: UploadOptions): Promise<ReferenceResponse> {
   const response = await safeAxios<ReferenceResponse>({
+    ...options?.axiosOptions,
     method: 'post',
     url: `${url}${endpoint}`,
     data,
@@ -27,7 +28,6 @@ export async function upload(url: string, data: Uint8Array, options?: UploadOpti
       ...extractUploadHeaders(options),
     },
     responseType: 'json',
-    ...options?.axiosOptions,
   })
 
   return response.data

--- a/src/modules/chunk.ts
+++ b/src/modules/chunk.ts
@@ -27,6 +27,7 @@ export async function upload(url: string, data: Uint8Array, options?: UploadOpti
       ...extractUploadHeaders(options),
     },
     responseType: 'json',
+    ...options?.axiosOptions,
   })
 
   return response.data

--- a/src/modules/collection.ts
+++ b/src/modules/collection.ts
@@ -135,6 +135,7 @@ export async function upload(
   const tarData = makeTar(data)
 
   const response = await safeAxios<{ reference: string }>({
+    ...options?.axiosOptions,
     method: 'post',
     url: `${url}${dirsEndpoint}`,
     data: tarData,
@@ -143,7 +144,6 @@ export async function upload(
       'content-type': 'application/x-tar',
       ...extractCollectionUploadHeaders(options),
     },
-    ...options?.axiosOptions,
   })
 
   return response.data.reference

--- a/src/modules/collection.ts
+++ b/src/modules/collection.ts
@@ -143,6 +143,7 @@ export async function upload(
       'content-type': 'application/x-tar',
       ...extractCollectionUploadHeaders(options),
     },
+    ...options?.axiosOptions,
   })
 
   return response.data.reference

--- a/src/modules/collection.ts
+++ b/src/modules/collection.ts
@@ -180,6 +180,7 @@ export async function download(url: string, hash: string, path = ''): Promise<Fi
  * @param url  Bee URL
  * @param hash Bee Collection hash
  * @param path Path of the requested file in the Collection
+ * @param axiosOptions optional - alter default options of axios HTTP client
  */
 export async function downloadReadable(
   url: string,

--- a/src/modules/collection.ts
+++ b/src/modules/collection.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs'
 import path from 'path'
 
 import type { CollectionUploadOptions, Collection, FileData, UploadHeaders } from '../types'
+import type { AxiosRequestConfig } from 'axios'
 import { makeTar } from '../utils/tar'
 import { safeAxios } from '../utils/safeAxios'
 import { extractUploadHeaders, readFileHeaders } from '../utils/headers'
@@ -180,7 +181,12 @@ export async function download(url: string, hash: string, path = ''): Promise<Fi
  * @param hash Bee Collection hash
  * @param path Path of the requested file in the Collection
  */
-export async function downloadReadable(url: string, hash: string, path = ''): Promise<FileData<Readable>> {
+export async function downloadReadable(
+  url: string,
+  hash: string,
+  path = '',
+  axiosOptions?: AxiosRequestConfig,
+): Promise<FileData<Readable>> {
   if (!url || url === '') {
     throw new BeeArgumentError('url parameter is required and cannot be empty', url)
   }
@@ -190,6 +196,8 @@ export async function downloadReadable(url: string, hash: string, path = ''): Pr
     url: `${url}${bzzEndpoint}/${hash}/${path}`,
   })
   const file = {
+    ...axiosOptions,
+    method: 'GET',
     ...readFileHeaders(response.headers),
     data: response.data,
   }

--- a/src/modules/file.ts
+++ b/src/modules/file.ts
@@ -1,3 +1,4 @@
+import { AxiosRequestConfig } from 'axios'
 import type { Readable } from 'stream'
 import { FileData, FileUploadOptions, UploadHeaders } from '../types'
 import { prepareData } from '../utils/data'
@@ -44,6 +45,7 @@ export async function upload(
     },
     responseType: 'json',
     params: { name },
+    ...options?.axiosOptions,
   })
 
   return response.data.reference
@@ -55,10 +57,15 @@ export async function upload(
  * @param url  Bee URL
  * @param hash Bee file hash
  */
-export async function download(url: string, hash: string): Promise<FileData<Uint8Array>> {
+export async function download(
+  url: string,
+  hash: string,
+  axiosOptions?: AxiosRequestConfig,
+): Promise<FileData<Uint8Array>> {
   const response = await safeAxios<ArrayBuffer>({
     responseType: 'arraybuffer',
     url: `${url}${endpoint}/${hash}`,
+    ...axiosOptions,
   })
   const file = {
     ...readFileHeaders(response.headers),
@@ -74,10 +81,15 @@ export async function download(url: string, hash: string): Promise<FileData<Uint
  * @param url  Bee URL
  * @param hash Bee file hash
  */
-export async function downloadReadable(url: string, hash: string): Promise<FileData<Readable>> {
+export async function downloadReadable(
+  url: string,
+  hash: string,
+  axiosOptions?: AxiosRequestConfig,
+): Promise<FileData<Readable>> {
   const response = await safeAxios<Readable>({
     responseType: 'stream',
     url: `${url}${endpoint}/${hash}`,
+    ...axiosOptions,
   })
   const file = {
     ...readFileHeaders(response.headers),

--- a/src/modules/file.ts
+++ b/src/modules/file.ts
@@ -27,7 +27,8 @@ function extractFileUploadHeaders(options?: FileUploadOptions): FileUploadHeader
  *
  * @param url     Bee URL
  * @param data    Data to be uploaded
- * @param options Aditional options like tag, encryption, pinning
+ * @param name    optional - name of the file
+ * @param options optional - Aditional options like tag, encryption, pinning
  */
 export async function upload(
   url: string,
@@ -56,6 +57,7 @@ export async function upload(
  *
  * @param url  Bee URL
  * @param hash Bee file hash
+ * @param axiosOptions optional - alter default options of axios HTTP client
  */
 export async function download(
   url: string,
@@ -81,6 +83,7 @@ export async function download(
  *
  * @param url  Bee URL
  * @param hash Bee file hash
+ * @param axiosOptions optional - alter default options of axios HTTP client
  */
 export async function downloadReadable(
   url: string,

--- a/src/modules/file.ts
+++ b/src/modules/file.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestConfig } from 'axios'
+import type { AxiosRequestConfig } from 'axios'
 import type { Readable } from 'stream'
 import { FileData, FileUploadOptions, UploadHeaders } from '../types'
 import { prepareData } from '../utils/data'

--- a/src/modules/file.ts
+++ b/src/modules/file.ts
@@ -64,6 +64,7 @@ export async function download(
 ): Promise<FileData<Uint8Array>> {
   const response = await safeAxios<ArrayBuffer>({
     ...axiosOptions,
+    method: 'GET',
     responseType: 'arraybuffer',
     url: `${url}${endpoint}/${hash}`,
   })
@@ -88,6 +89,7 @@ export async function downloadReadable(
 ): Promise<FileData<Readable>> {
   const response = await safeAxios<Readable>({
     ...axiosOptions,
+    method: 'GET',
     responseType: 'stream',
     url: `${url}${endpoint}/${hash}`,
   })

--- a/src/modules/file.ts
+++ b/src/modules/file.ts
@@ -36,6 +36,7 @@ export async function upload(
   options?: FileUploadOptions,
 ): Promise<string> {
   const response = await safeAxios<{ reference: string }>({
+    ...options?.axiosOptions,
     method: 'post',
     url: url + endpoint,
     data: prepareData(data),
@@ -45,7 +46,6 @@ export async function upload(
     },
     responseType: 'json',
     params: { name },
-    ...options?.axiosOptions,
   })
 
   return response.data.reference
@@ -63,9 +63,9 @@ export async function download(
   axiosOptions?: AxiosRequestConfig,
 ): Promise<FileData<Uint8Array>> {
   const response = await safeAxios<ArrayBuffer>({
+    ...axiosOptions,
     responseType: 'arraybuffer',
     url: `${url}${endpoint}/${hash}`,
-    ...axiosOptions,
   })
   const file = {
     ...readFileHeaders(response.headers),
@@ -87,9 +87,9 @@ export async function downloadReadable(
   axiosOptions?: AxiosRequestConfig,
 ): Promise<FileData<Readable>> {
   const response = await safeAxios<Readable>({
+    ...axiosOptions,
     responseType: 'stream',
     url: `${url}${endpoint}/${hash}`,
-    ...axiosOptions,
   })
   const file = {
     ...readFileHeaders(response.headers),

--- a/src/modules/soc.ts
+++ b/src/modules/soc.ts
@@ -32,6 +32,7 @@ export async function upload(
     },
     responseType: 'json',
     params: { sig: signature },
+    ...options?.axiosOptions,
   })
 
   return response.data

--- a/src/modules/soc.ts
+++ b/src/modules/soc.ts
@@ -23,6 +23,7 @@ export async function upload(
   options?: UploadOptions,
 ): Promise<ReferenceResponse> {
   const response = await safeAxios<ReferenceResponse>({
+    ...options?.axiosOptions,
     method: 'post',
     url: `${url}${socEndpoint}/${owner}/${identifier}`,
     data,
@@ -32,7 +33,6 @@ export async function upload(
     },
     responseType: 'json',
     params: { sig: signature },
-    ...options?.axiosOptions,
   })
 
   return response.data

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,6 +18,7 @@ export interface UploadOptions {
   pin?: boolean
   encrypt?: boolean
   tag?: number
+  /** alter default options of axios HTTP client */
   axiosOptions?: AxiosRequestConfig
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 import { BeeError } from '../utils/error'
+import type { AxiosRequestConfig } from 'axios'
 
 export interface Dictionary<T> {
   [Key: string]: T
@@ -17,6 +18,7 @@ export interface UploadOptions {
   pin?: boolean
   encrypt?: boolean
   tag?: number
+  axiosOptions?: AxiosRequestConfig
 }
 
 export interface FileUploadOptions extends UploadOptions {

--- a/test/bee-class.browser.spec.ts
+++ b/test/bee-class.browser.spec.ts
@@ -1,5 +1,5 @@
 import { join } from 'path'
-import { beeUrl, commonMatchers, randomByteArray } from './utils'
+import { beeUrl, commonMatchers } from './utils'
 import '../src'
 
 commonMatchers()
@@ -60,8 +60,8 @@ describe('Bee class - in browser', () => {
       const bee = new window.BeeJs.Bee(BEE_URL)
       const filename = 'hello.txt'
       const data = new Uint8Array([1, 2, 3, 4])
-      // eslint-disable-next-line prettier/prettier
-      let uploadEvent: { loaded: number, total: number } = {
+
+      let uploadEvent: { loaded: number; total: number } = {
         loaded: 0,
         total: 4,
       }

--- a/test/bee-class.browser.spec.ts
+++ b/test/bee-class.browser.spec.ts
@@ -1,5 +1,5 @@
 import { join } from 'path'
-import { beeUrl, commonMatchers } from './utils'
+import { beeUrl, commonMatchers, randomByteArray } from './utils'
 import '../src'
 
 commonMatchers()
@@ -53,5 +53,31 @@ describe('Bee class - in browser', () => {
     )
     expect(pinResult).toBeBeeResponse(200)
     expect(unpinResult).toBeBeeResponse(200)
+  })
+
+  it('should get state of uploading on uploading file', async () => {
+    const uploadEvent = await page.evaluate(async BEE_URL => {
+      const bee = new window.BeeJs.Bee(BEE_URL)
+      const filename = 'hello.txt'
+      const data = new Uint8Array([1, 2, 3, 4])
+      // eslint-disable-next-line prettier/prettier
+      let uploadEvent: { loaded: number, total: number } = {
+        loaded: 0,
+        total: 4,
+      }
+
+      await bee.uploadFile(data, filename, {
+        contentType: 'text/html',
+        axiosOptions: {
+          onUploadProgress: ({ loaded, total }) => {
+            uploadEvent = { loaded, total }
+          },
+        },
+      })
+
+      return uploadEvent
+    }, BEE_URL)
+
+    expect(uploadEvent).toEqual({ loaded: 4, total: 4 })
   })
 })


### PR DESCRIPTION
On uploading and downloading big files would be nice to provide `onProgress` to keep track with the uploading/downloading and configurate other request related options.
`bee-js` make HTTP requests by `axios`, so this PR simply exposes its options on related functions and methods. 

Resolves #133