### PR TITLE
fix: upload SOC twice

### DIFF
--- a/src/modules/debug/chunk.ts
+++ b/src/modules/debug/chunk.ts
@@ -1,0 +1,39 @@
+import { BeeResponse } from '../../types'
+import { safeAxios } from '../../utils/safeAxios'
+
+const endpoint = '/chunks'
+
+/**
+ * Check if chunk at address exists locally
+ *
+ * @param url      Bee debug url
+ * @param address  Swarm address of chunk
+ *
+ * @returns BeeResponse if chunk is found or throws an exception
+ */
+export async function checkIfChunkExistsLocally(url: string, address: string): Promise<BeeResponse> {
+  const response = await safeAxios<BeeResponse>({
+    url: url + endpoint + `/${address}`,
+    responseType: 'json',
+  })
+
+  return response.data
+}
+
+/**
+ * Delete a chunk from local storage
+ *
+ * @param url      Bee debug url
+ * @param address  Swarm address of chunk
+ *
+ * @returns BeeResponse if chunk was deleted or throws an exception
+ */
+export async function deleteChunkFromLocalStorage(url: string, address: string): Promise<BeeResponse> {
+  const response = await safeAxios<BeeResponse>({
+    method: 'delete',
+    url: url + endpoint + `/${address}`,
+    responseType: 'json',
+  })
+
+  return response.data
+}

--- a/test/bee-class.spec.ts
+++ b/test/bee-class.spec.ts
@@ -232,6 +232,7 @@ describe('Bee class', () => {
       expect(secondUpdateReferenceResponse.feedIndex).toEqual('0000000000000001')
       // TODO the timeout was increased because this test is flaky
       // most likely there is an issue with the lookup
+      // https://github.com/ethersphere/bee/issues/1248#issuecomment-786588911
     }, 120000)
 
     describe('topic', () => {

--- a/test/bee-class.spec.ts
+++ b/test/bee-class.spec.ts
@@ -230,7 +230,9 @@ describe('Bee class', () => {
 
       expect(secondUpdateReferenceResponse.reference).toEqual(bytesToHex(referenceOne))
       expect(secondUpdateReferenceResponse.feedIndex).toEqual('0000000000000001')
-    }, 60000)
+      // TODO the timeout was increased because this test is flaky
+      // most likely there is an issue with the lookup
+    }, 120000)
 
     describe('topic', () => {
       test('create feed topic', () => {

--- a/test/chunk/soc.spec.ts
+++ b/test/chunk/soc.spec.ts
@@ -1,7 +1,7 @@
 import { Bytes, verifyBytes } from '../../src/utils/bytes'
 import { makeSingleOwnerChunk, verifySingleOwnerChunk, uploadSingleOwnerChunk } from '../../src/chunk/soc'
 import { makeContentAddressedChunk, verifyChunk } from '../../src/chunk/cac'
-import { beeUrl, testIdentity } from '../utils'
+import { beeUrl, testIdentity, tryDeleteChunkFromLocalStorage } from '../utils'
 import { makeDefaultSigner } from '../../src/chunk/signer'
 import { serializeBytes } from '../../src/chunk/serialize'
 import { makeSpan } from '../../src/chunk/span'
@@ -64,6 +64,8 @@ describe('soc', () => {
     const cac = makeContentAddressedChunk(payload)
     const soc = await makeSingleOwnerChunk(cac, identifier, signer)
     const socAddress = bytesToHex(soc.address())
+
+    await tryDeleteChunkFromLocalStorage(socHash)
 
     const response = await uploadSingleOwnerChunk(beeUrl(), soc)
 

--- a/test/feed/index.spec.ts
+++ b/test/feed/index.spec.ts
@@ -1,11 +1,13 @@
 import { fetchFeedUpdate } from '../../src/modules/feed'
 import { HexString, hexToBytes, stripHexPrefix, verifyHex } from '../../src/utils/hex'
 import { beeUrl, testIdentity } from '../utils'
-import { ChunkReference, downloadFeedUpdate, findNextIndex, uploadFeedUpdate } from '../../src/feed'
+import { ChunkReference, downloadFeedUpdate, findNextIndex, Index, uploadFeedUpdate } from '../../src/feed'
 import { Bytes, verifyBytes } from '../../src/utils/bytes'
-import { makeDefaultSigner, PrivateKey } from '../../src/chunk/signer'
+import { makeDefaultSigner, PrivateKey, Signer } from '../../src/chunk/signer'
 import { makeContentAddressedChunk } from '../../src/chunk/cac'
 import * as chunkAPI from '../../src/modules/chunk'
+import { Topic } from '../../src/feed/topic'
+import { BeeResponseError } from '../../src'
 
 function makeChunk(index: number) {
   return makeContentAddressedChunk(new Uint8Array([index]))
@@ -16,6 +18,18 @@ async function uploadChunk(url: string, index: number): Promise<ChunkReference> 
   const referenceResponse = await chunkAPI.upload(url, chunk.data)
 
   return hexToBytes(referenceResponse.reference as HexString) as ChunkReference
+}
+
+async function tryUploadFeedUpdate(url: string, signer: Signer, topic: Topic, index: Index, reference: ChunkReference) {
+  try {
+    await uploadFeedUpdate(url, signer, topic, index, reference)
+  } catch (e) {
+    if (e instanceof BeeResponseError && e.status === 409) {
+      // ignore conflict errors when uploading the same feed update twice
+      return
+    }
+    throw e
+  }
 }
 
 describe('feed', () => {
@@ -35,7 +49,7 @@ describe('feed', () => {
     const topicBytes = hexToBytes(topic) as Bytes<32>
 
     const uploadedChunk = await uploadChunk(url, 0)
-    await uploadFeedUpdate(url, signer, topicBytes, 0, uploadedChunk)
+    await tryUploadFeedUpdate(url, signer, topicBytes, 0, uploadedChunk)
 
     const feedUpdate = await fetchFeedUpdate(url, owner, topic)
 
@@ -53,7 +67,7 @@ describe('feed', () => {
 
     for (let i = 0; i < numUpdates; i++) {
       const referenceI = new Uint8Array([i, ...referenceBytes.slice(1)]) as Bytes<32>
-      await uploadFeedUpdate(url, signer, topicBytes, i, referenceI)
+      await tryUploadFeedUpdate(url, signer, topicBytes, i, referenceI)
     }
 
     for (let i = 0; i < numUpdates; i++) {

--- a/test/feed/index.spec.ts
+++ b/test/feed/index.spec.ts
@@ -20,6 +20,8 @@ async function uploadChunk(url: string, index: number): Promise<ChunkReference> 
   return hexToBytes(referenceResponse.reference as HexString) as ChunkReference
 }
 
+// helper function for setting up test state for testing finding feed updates
+// it is not intended as a replacement in tests for `uploadFeedUpdate`
 async function tryUploadFeedUpdate(url: string, signer: Signer, topic: Topic, index: Index, reference: ChunkReference) {
   try {
     await uploadFeedUpdate(url, signer, topic, index, reference)

--- a/test/feed/index.spec.ts
+++ b/test/feed/index.spec.ts
@@ -20,8 +20,9 @@ async function uploadChunk(url: string, index: number): Promise<ChunkReference> 
   return hexToBytes(referenceResponse.reference as HexString) as ChunkReference
 }
 
-// helper function for setting up test state for testing finding feed updates
+// FIXME helper function for setting up test state for testing finding feed updates
 // it is not intended as a replacement in tests for `uploadFeedUpdate`
+// https://github.com/ethersphere/bee-js/issues/154
 async function tryUploadFeedUpdate(url: string, signer: Signer, topic: Topic, index: Index, reference: ChunkReference) {
   try {
     await uploadFeedUpdate(url, signer, topic, index, reference)

--- a/test/modules/feed.spec.ts
+++ b/test/modules/feed.spec.ts
@@ -1,6 +1,6 @@
 import { createFeedManifest, fetchFeedUpdate } from '../../src/modules/feed'
 import { HexString, hexToBytes, stripHexPrefix } from '../../src/utils/hex'
-import { beeUrl, testIdentity } from '../utils'
+import { beeUrl, testIdentity, tryDeleteChunkFromLocalStorage } from '../utils'
 import { upload as uploadSOC } from '../../src/modules/soc'
 
 describe('modules/feed', () => {
@@ -30,6 +30,11 @@ describe('modules/feed', () => {
     const socData = hexToBytes(
       '280000000000000000000000602a57df0000000000000000000000000000000000000000000000000000000000000000' as HexString,
     )
+
+    // delete the chunk from local storage if already exists
+    // this makes the test repeatable
+    const cacAddress = '03e8eef6d72dbca9dfb7d2e15a5a305a152a3807ac7fd5ea52721a16972f3813'
+    await tryDeleteChunkFromLocalStorage(cacAddress)
 
     const socResponse = await uploadSOC(url, owner, identifier, signature, socData)
     expect(typeof socResponse.reference).toBe('string')

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -2,6 +2,7 @@ import { Readable } from 'stream'
 import type { BeeResponse } from '../src/types'
 import { HexString } from '../src/utils/hex'
 import { deleteChunkFromLocalStorage } from '../src/modules/debug/chunk'
+import { BeeResponseError } from '../src'
 
 /**
  * Load common own Jest Matchers which can be used to check particular return values.
@@ -124,7 +125,11 @@ export async function tryDeleteChunkFromLocalStorage(address: string): Promise<v
   try {
     await deleteChunkFromLocalStorage(beeDebugUrl(), address)
   } catch (e) {
-    // ignore errors
+    // ignore not found errors
+    if (e instanceof BeeResponseError && e.status === 404) {
+      return
+    }
+    throw e
   }
 }
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,6 +1,7 @@
 import { Readable } from 'stream'
 import type { BeeResponse } from '../src/types'
 import { HexString } from '../src/utils/hex'
+import { deleteChunkFromLocalStorage } from '../src/modules/debug/chunk'
 
 /**
  * Load common own Jest Matchers which can be used to check particular return values.
@@ -112,6 +113,19 @@ export function beeDebugUrl(url: string = beeUrl()): string {
   const port = urlObj.port ? parseInt(urlObj.port, 10) + 2 : 1635
 
   return urlObj.protocol + '//' + urlObj.hostname + ':' + port
+}
+
+/**
+ * Try to delete a chunk from local storage, ignoring all errors
+ *
+ * @param address  Swarm address of chunk
+ */
+export async function tryDeleteChunkFromLocalStorage(address: string): Promise<void> {
+  try {
+    await deleteChunkFromLocalStorage(beeDebugUrl(), address)
+  } catch (e) {
+    // ignore errors
+  }
 }
 
 export const invalidReference = '0000000000000000000000000000000000000000000000000000000000000000'


### PR DESCRIPTION
Add functionality to delete chunks from local storage to make tests repeatable. Also add helper functions for tests to ignore certain errors.

This PR is forked from `feat/feed-interface` not from master to make the review easier. Once it is approved it will be merged back to it, then that can be merged back to master.