### PR TITLE
feat: expose the getPeers function on `BeeDebug`

### DIFF
--- a/src/bee-debug.ts
+++ b/src/bee-debug.ts
@@ -24,6 +24,13 @@ export class BeeDebug {
     return nodeAddresses.pss_public_key
   }
 
+  /**
+   * Get list of peers for this node
+   */
+  getPeers(): Promise<connectivity.Peers> {
+    return connectivity.getPeers(this.url)
+  }
+
   /*
    * Balance endpoints
    */

--- a/test/modules/debug/connectivity.spec.ts
+++ b/test/modules/debug/connectivity.spec.ts
@@ -1,0 +1,16 @@
+import { getPeers } from '../../../src/modules/debug/connectivity'
+import { beeDebugUrl } from '../../utils'
+
+describe('getPeers', () => {
+  test('address', async () => {
+    const { peers } = await getPeers(beeDebugUrl())
+
+    expect(Array.isArray(peers)).toBeTruthy()
+    expect(peers.length).toBeGreaterThan(0)
+
+    peers.forEach(peer => {
+      expect(peer).toHaveProperty('address')
+      expect(peer.address).toMatch(/^[0-9a-f]{64}$/i)
+    })
+  })
+})


### PR DESCRIPTION
resolves #153 