### PR TITLE
Correct getChequebookBalance spelling (remove extra u)

### DIFF
--- a/src/bee-debug.ts
+++ b/src/bee-debug.ts
@@ -97,8 +97,8 @@ export class BeeDebug {
   /**
    * Get the balance of the chequebook
    */
-  getChequeubookBalance(): Promise<ChequebookBalanceResponse> {
-    return chequebook.getChequeubookBalance(this.url)
+  getChequebookBalance(): Promise<ChequebookBalanceResponse> {
+    return chequebook.getChequebookBalance(this.url)
   }
 
   /**

--- a/src/modules/debug/chequebook.ts
+++ b/src/modules/debug/chequebook.ts
@@ -31,7 +31,7 @@ export async function getChequebookAddress(url: string): Promise<ChequebookAddre
  *
  * @param url Bee debug url
  */
-export async function getChequeubookBalance(url: string): Promise<ChequebookBalanceResponse> {
+export async function getChequebookBalance(url: string): Promise<ChequebookBalanceResponse> {
   const response = await safeAxios<ChequebookBalanceResponse>({
     url: url + chequebookEndpoint + '/balance',
     responseType: 'json',

--- a/test/modules/debug/chequebook.spec.ts
+++ b/test/modules/debug/chequebook.spec.ts
@@ -1,7 +1,7 @@
 import {
   depositTokens,
   getChequebookAddress,
-  getChequeubookBalance,
+  getChequebookBalance,
   getLastCheques,
   withdrawTokens,
 } from '../../../src/modules/debug/chequebook'
@@ -17,7 +17,7 @@ if (process.env.BEE_TEST_CHEQUEBOOK) {
     })
 
     test('balance', async () => {
-      const response = await getChequeubookBalance(beeDebugUrl())
+      const response = await getChequebookBalance(beeDebugUrl())
 
       expect(typeof response.availableBalance).toBe('number')
       expect(typeof response.totalBalance).toBe('number')


### PR DESCRIPTION
Unless there was a reason for the extra "u" in getChequeubookBalance, this brings the names to a consistency.