### PR TITLE
ci: use different node versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,6 +30,11 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
       # Setup Bee environment
       - name: Install bee-local
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 15.x]
 
     steps:
       - name: Checkout

--- a/test/bee-class.spec.ts
+++ b/test/bee-class.spec.ts
@@ -26,6 +26,9 @@ describe('Bee class', () => {
   const BEE_URL = beeUrl()
   const bee = new Bee(BEE_URL)
 
+  // eslint-disable-next-line no-console
+  console.log('Process.versions: ', process.versions)
+
   function testUrl(url: unknown): void {
     it(`should not accept invalid url '${url}'`, () => {
       try {

--- a/test/bee-class.spec.ts
+++ b/test/bee-class.spec.ts
@@ -26,9 +26,6 @@ describe('Bee class', () => {
   const BEE_URL = beeUrl()
   const bee = new Bee(BEE_URL)
 
-  // eslint-disable-next-line no-console
-  console.log('Process.versions: ', process.versions)
-
   function testUrl(url: unknown): void {
     it(`should not accept invalid url '${url}'`, () => {
       try {


### PR DESCRIPTION
Fixes CI to correctly use the specified node versions. Up till now it was running on the Github's NodeJS default version (v14).