### PR TITLE
ci: using specific version of the bee node for tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -106,7 +106,7 @@ jobs:
           export URL=$(curl -s https://api.github.com/repos/ethersphere/bee-local/releases/latest | jq -r .tarball_url)
           curl -Ls ${URL} -o bee-local.tar.gz
           tar --strip-components=1 --wildcards -xzf bee-local.tar.gz ethersphere-bee-local-*/{beeinfra.sh,helm-values,hack}
-          sed -i "s/IMAGE_TAG='latest'/IMAGE_TAG='beta'/" beeinfra.sh
+          sed -i 's/IMAGE_TAG="latest"/IMAGE_TAG='\"${BEE_VERSION}\"'/' beeinfra.sh
       - name: Install latest beekeeper
         run: |
           export TAG=$(curl -s https://api.github.com/repos/ethersphere/beekeeper/releases/latest | jq -r .tag_name)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ on:
 
 
 env:
-  BEE_VERSION: '0.5.3'
+  BEE_VERSION: 'beta'
   REPLICA: 5
   BEE_API_URL: 'http://bee-0.localhost'
   BEE_PEER_API_URL: 'http://bee-1.localhost'
@@ -42,7 +42,7 @@ jobs:
           export URL=$(curl -s https://api.github.com/repos/ethersphere/bee-local/releases/latest | jq -r .tarball_url)
           curl -Ls ${URL} -o bee-local.tar.gz
           tar --strip-components=1 --wildcards -xzf bee-local.tar.gz ethersphere-bee-local-*/{beeinfra.sh,helm-values,hack}
-          sed -i "s/IMAGE_TAG='beta'/IMAGE_TAG='${BEE_VERSION}'/" beeinfra.sh
+          sed -i "s/IMAGE_TAG='latest'/IMAGE_TAG='${BEE_VERSION}'/" beeinfra.sh
       - name: Install latest beekeeper
         run: |
           export TAG=$(curl -s https://api.github.com/repos/ethersphere/beekeeper/releases/latest | jq -r .tag_name)
@@ -106,7 +106,7 @@ jobs:
           export URL=$(curl -s https://api.github.com/repos/ethersphere/bee-local/releases/latest | jq -r .tarball_url)
           curl -Ls ${URL} -o bee-local.tar.gz
           tar --strip-components=1 --wildcards -xzf bee-local.tar.gz ethersphere-bee-local-*/{beeinfra.sh,helm-values,hack}
-          sed -i "s/IMAGE_TAG='beta'/IMAGE_TAG='${BEE_VERSION}'/" beeinfra.sh
+          sed -i "s/IMAGE_TAG='latest'/IMAGE_TAG='${BEE_VERSION}'/" beeinfra.sh
       - name: Install latest beekeeper
         run: |
           export TAG=$(curl -s https://api.github.com/repos/ethersphere/beekeeper/releases/latest | jq -r .tag_name)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
           export URL=$(curl -s https://api.github.com/repos/ethersphere/bee-local/releases/latest | jq -r .tarball_url)
           curl -Ls ${URL} -o bee-local.tar.gz
           tar --strip-components=1 --wildcards -xzf bee-local.tar.gz ethersphere-bee-local-*/{beeinfra.sh,helm-values,hack}
-          sed -i "s/IMAGE_TAG='latest'/IMAGE_TAG='${BEE_VERSION}'/" beeinfra.sh
+          sed -i "s/IMAGE_TAG='beta'/IMAGE_TAG='${BEE_VERSION}'/" beeinfra.sh
       - name: Install latest beekeeper
         run: |
           export TAG=$(curl -s https://api.github.com/repos/ethersphere/beekeeper/releases/latest | jq -r .tag_name)
@@ -106,7 +106,7 @@ jobs:
           export URL=$(curl -s https://api.github.com/repos/ethersphere/bee-local/releases/latest | jq -r .tarball_url)
           curl -Ls ${URL} -o bee-local.tar.gz
           tar --strip-components=1 --wildcards -xzf bee-local.tar.gz ethersphere-bee-local-*/{beeinfra.sh,helm-values,hack}
-          sed -i "s/IMAGE_TAG='latest'/IMAGE_TAG='${BEE_VERSION}'/" beeinfra.sh
+          sed -i "s/IMAGE_TAG='beta'/IMAGE_TAG='${BEE_VERSION}'/" beeinfra.sh
       - name: Install latest beekeeper
         run: |
           export TAG=$(curl -s https://api.github.com/repos/ethersphere/beekeeper/releases/latest | jq -r .tag_name)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
           export URL=$(curl -s https://api.github.com/repos/ethersphere/bee-local/releases/latest | jq -r .tarball_url)
           curl -Ls ${URL} -o bee-local.tar.gz
           tar --strip-components=1 --wildcards -xzf bee-local.tar.gz ethersphere-bee-local-*/{beeinfra.sh,helm-values,hack}
-          sed -i "s/IMAGE_TAG='latest'/IMAGE_TAG='${BEE_VERSION}'/" beeinfra.sh
+          sed -i "s/IMAGE_TAG='latest'/IMAGE_TAG='beta'/" beeinfra.sh
       - name: Install latest beekeeper
         run: |
           export TAG=$(curl -s https://api.github.com/repos/ethersphere/beekeeper/releases/latest | jq -r .tag_name)
@@ -106,7 +106,7 @@ jobs:
           export URL=$(curl -s https://api.github.com/repos/ethersphere/bee-local/releases/latest | jq -r .tarball_url)
           curl -Ls ${URL} -o bee-local.tar.gz
           tar --strip-components=1 --wildcards -xzf bee-local.tar.gz ethersphere-bee-local-*/{beeinfra.sh,helm-values,hack}
-          sed -i "s/IMAGE_TAG='latest'/IMAGE_TAG='${BEE_VERSION}'/" beeinfra.sh
+          sed -i "s/IMAGE_TAG='latest'/IMAGE_TAG='beta'/" beeinfra.sh
       - name: Install latest beekeeper
         run: |
           export TAG=$(curl -s https://api.github.com/repos/ethersphere/beekeeper/releases/latest | jq -r .tag_name)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ on:
 
 
 env:
-  BEE_VERSION: 'beta'
+  BEE_VERSION: 'v0.5.3'
   REPLICA: 5
   BEE_API_URL: 'http://bee-0.localhost'
   BEE_PEER_API_URL: 'http://bee-1.localhost'
@@ -42,7 +42,7 @@ jobs:
           export URL=$(curl -s https://api.github.com/repos/ethersphere/bee-local/releases/latest | jq -r .tarball_url)
           curl -Ls ${URL} -o bee-local.tar.gz
           tar --strip-components=1 --wildcards -xzf bee-local.tar.gz ethersphere-bee-local-*/{beeinfra.sh,helm-values,hack}
-          sed -i "s/IMAGE_TAG='latest'/IMAGE_TAG='beta'/" beeinfra.sh
+          sed -i 's/IMAGE_TAG="latest"/IMAGE_TAG='\"${BEE_VERSION}\"'/' beeinfra.sh
       - name: Install latest beekeeper
         run: |
           export TAG=$(curl -s https://api.github.com/repos/ethersphere/beekeeper/releases/latest | jq -r .tag_name)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ on:
 
 
 env:
-  BEE_VERSION: 'v0.5.3'
+  BEE_VERSION: '0.5.3'
   REPLICA: 5
   BEE_API_URL: 'http://bee-0.localhost'
   BEE_PEER_API_URL: 'http://bee-1.localhost'


### PR DESCRIPTION
Seems that in past we always used `latest` tag as the `sed` did not work. I introduced this with #193 