### PR TITLE
feat: ethereum wallet signer utility

### DIFF
--- a/src/utils/eth.ts
+++ b/src/utils/eth.ts
@@ -218,7 +218,7 @@ export async function makeEthereumWalletSigner(
       const result = await executorFnc({
         jsonrpc: '2.0',
         method: 'personal_sign',
-        params: ['0x' + hexEthAddress, '0x' + data.hex()],
+        params: ['0x' + data.hex(), '0x' + hexEthAddress],
       })
 
       return result as string

--- a/src/utils/eth.ts
+++ b/src/utils/eth.ts
@@ -210,7 +210,7 @@ export async function createEthereumWalletSigner(
   }
 
   const bytesEthAddress = makeEthAddress(ethAddress)
-  ethAddress = makeHexEthAddress(ethAddress)
+  const hexEthAddress = makeHexEthAddress(ethAddress)
 
   return {
     address: bytesEthAddress,
@@ -218,7 +218,7 @@ export async function createEthereumWalletSigner(
       const result = await executorFnc({
         jsonrpc: '2.0',
         method: 'personal_sign',
-        params: ['0x' + ethAddress, '0x' + data.hex()],
+        params: ['0x' + hexEthAddress, '0x' + data.hex()],
       })
 
       return result as string

--- a/src/utils/eth.ts
+++ b/src/utils/eth.ts
@@ -1,7 +1,8 @@
 import { keccak256, sha3_256 } from 'js-sha3'
-import { BrandedString } from '../types'
+import { BrandedString, Data } from '../types'
 import { HexString, hexToBytes, intToHex, makeHexString, assertHexString } from './hex'
 import { Bytes, verifyBytes } from './bytes'
+import { Signer } from '../chunk/signer'
 
 export type OverlayAddress = BrandedString<'OverlayAddress'>
 export type EthAddress = Bytes<20>
@@ -166,4 +167,61 @@ export function ethToSwarmAddress(ethAddress: string | HexString | HexEthAddress
   const overlayAddress = sha3_256(hexToBytes(hex))
 
   return overlayAddress as OverlayAddress
+}
+
+interface RequestArguments {
+  jsonrpc?: string
+  method: string
+  params?: unknown[] | object
+}
+
+export interface JsonRPC {
+  request?(args: RequestArguments): Promise<unknown>
+  sendAsync?(args: RequestArguments): Promise<unknown>
+}
+
+/**
+ * Function that takes Ethereum EIP-1102 compatible provider and create an Signer instance that
+ * uses personal_sign method to sign requested data.
+ *
+ * @param provider
+ * @param ethAddress Optional address of the account which the data should be signed with. If not specified eth_requestAccounts requests is used to get the account address.
+ */
+export async function createEthereumWalletSigner(
+  provider: JsonRPC,
+  ethAddress?: string | HexString | HexEthAddress,
+): Promise<Signer> {
+  let executorFnc: (args: RequestArguments) => Promise<unknown>
+
+  if (typeof provider !== 'object' || provider === null) {
+    throw new TypeError('We need JsonRPC provider object!')
+  }
+
+  if (provider.request) {
+    executorFnc = provider.request
+  } else if (provider.sendAsync) {
+    executorFnc = provider.sendAsync
+  } else {
+    throw new Error('Incompatible interface of given provider!')
+  }
+
+  if (!ethAddress) {
+    ethAddress = ((await executorFnc({ method: 'eth_requestAccounts' })) as string[])[0]
+  }
+
+  const bytesEthAddress = makeEthAddress(ethAddress)
+  ethAddress = makeHexEthAddress(ethAddress)
+
+  return {
+    address: bytesEthAddress,
+    sign: async (data: Data): Promise<string> => {
+      const result = await executorFnc({
+        jsonrpc: '2.0',
+        method: 'personal_sign',
+        params: ['0x' + ethAddress, '0x' + data.hex()],
+      })
+
+      return result as string
+    },
+  } as Signer
 }

--- a/src/utils/eth.ts
+++ b/src/utils/eth.ts
@@ -172,7 +172,7 @@ export function ethToSwarmAddress(ethAddress: string | HexString | HexEthAddress
 interface RequestArguments {
   jsonrpc?: string
   method: string
-  params?: unknown[] | object
+  params?: unknown[] | Record<string, unknown>
 }
 
 export interface JsonRPC {

--- a/src/utils/eth.ts
+++ b/src/utils/eth.ts
@@ -170,8 +170,8 @@ export function ethToSwarmAddress(ethAddress: string | HexString | HexEthAddress
 }
 
 interface RequestArguments {
-  jsonrpc?: string
   method: string
+  jsonrpc?: string
   params?: unknown[] | Record<string, unknown>
 }
 
@@ -181,13 +181,13 @@ export interface JsonRPC {
 }
 
 /**
- * Function that takes Ethereum EIP-1102 compatible provider and create an Signer instance that
+ * Function that takes Ethereum EIP-1193 compatible provider and create an Signer instance that
  * uses personal_sign method to sign requested data.
  *
- * @param provider
+ * @param provider Injected web3 provider like window.ethereum or other compatible with EIP-1193
  * @param ethAddress Optional address of the account which the data should be signed with. If not specified eth_requestAccounts requests is used to get the account address.
  */
-export async function createEthereumWalletSigner(
+export async function makeEthereumWalletSigner(
   provider: JsonRPC,
   ethAddress?: string | HexString | HexEthAddress,
 ): Promise<Signer> {

--- a/test/utils/eth.spec.ts
+++ b/test/utils/eth.spec.ts
@@ -1,5 +1,14 @@
 /* eslint @typescript-eslint/no-empty-function: 0 */
-import { ethToSwarmAddress, fromLittleEndian, isHexEthAddress, toLittleEndian } from '../../src/utils/eth'
+import {
+  createEthereumWalletSigner,
+  ethToSwarmAddress,
+  fromLittleEndian,
+  isHexEthAddress,
+  JsonRPC,
+  toLittleEndian,
+} from '../../src/utils/eth'
+import { HexString, hexToBytes } from '../../src/utils/hex'
+import { wrapBytesWithHelpers } from '../../src/utils/bytes'
 
 describe('eth', () => {
   describe('isEthAddress', () => {
@@ -136,5 +145,79 @@ describe('eth', () => {
         expect(() => ethToSwarmAddress((address as unknown) as string, (netId as unknown) as number)).toThrow()
       }),
     )
+  })
+
+  describe('createEthereumWalletSigner', () => {
+    const dataToSignBytes = hexToBytes('2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae' as HexString)
+    const dataToSignWithHelpers = wrapBytesWithHelpers(dataToSignBytes)
+    const expectedSignatureHex = '0x336d24afef78c5883b96ad9a62552a8db3d236105cb059ddd04dc49680869dc16234f6852c277087f025d4114c4fac6b40295ecffd1194a84cdb91bd571769491b' as HexString
+
+    it('should detect valid interface', async () => {
+      await expect(createEthereumWalletSigner({})).rejects.toThrow()
+      await expect(createEthereumWalletSigner(('' as unknown) as JsonRPC)).rejects.toThrow(TypeError)
+      await expect(createEthereumWalletSigner((1 as unknown) as JsonRPC)).rejects.toThrow(TypeError)
+      await expect(createEthereumWalletSigner((null as unknown) as JsonRPC)).rejects.toThrow(TypeError)
+      await expect(createEthereumWalletSigner((undefined as unknown) as JsonRPC)).rejects.toThrow(TypeError)
+    })
+
+    it('should request address if not specified', async () => {
+      const providerMock = jest.fn()
+      providerMock.mockReturnValue(['0xf1B07aC6E91A423d9c3c834cc9d938E89E19334a'])
+
+      const signer = await createEthereumWalletSigner({ request: providerMock } as JsonRPC)
+
+      expect(signer.address).toEqual(hexToBytes('f1B07aC6E91A423d9c3c834cc9d938E89E19334a'))
+      expect(providerMock.mock.calls.length).toEqual(1)
+      expect(providerMock.mock.calls[0][0]).toEqual({ method: 'eth_requestAccounts' })
+    })
+
+    it('should request signature when sign() is called', async () => {
+      const providerMock = jest.fn()
+      providerMock.mockReturnValue(expectedSignatureHex)
+
+      const signer = await createEthereumWalletSigner(
+        { request: providerMock } as JsonRPC,
+        '0xf1B07aC6E91A423d9c3c834cc9d938E89E19334a',
+      )
+      await expect(signer.sign(dataToSignWithHelpers)).resolves.toEqual(expectedSignatureHex)
+      expect(providerMock.mock.calls.length).toEqual(1)
+      expect(providerMock.mock.calls[0][0]).toEqual({
+        jsonrpc: '2.0',
+        method: 'personal_sign',
+        params: [
+          '0xf1B07aC6E91A423d9c3c834cc9d938E89E19334a',
+          '0x2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
+        ],
+      })
+    })
+
+    it('should normalize hex prefix for address', async () => {
+      const providerMock = jest.fn()
+      providerMock.mockReturnValue(expectedSignatureHex)
+
+      const signer = await createEthereumWalletSigner(
+        { request: providerMock } as JsonRPC,
+        'f1B07aC6E91A423d9c3c834cc9d938E89E19334a',
+      )
+      await expect(signer.sign(dataToSignWithHelpers)).resolves.toEqual(expectedSignatureHex)
+      expect(providerMock.mock.calls.length).toEqual(1)
+      expect(providerMock.mock.calls[0][0]).toEqual({
+        jsonrpc: '2.0',
+        method: 'personal_sign',
+        params: [
+          '0xf1B07aC6E91A423d9c3c834cc9d938E89E19334a',
+          '0x2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
+        ],
+      })
+    })
+
+    it('should validate eth address', async () => {
+      const providerMock = jest.fn()
+      providerMock.mockReturnValue(expectedSignatureHex)
+
+      await expect(
+        createEthereumWalletSigner({ request: providerMock } as JsonRPC, '0x307aC6E91A423d9c3c834cc9d938E89E19334a'),
+      ).rejects.toThrow(TypeError)
+    })
   })
 })

--- a/test/utils/eth.spec.ts
+++ b/test/utils/eth.spec.ts
@@ -147,7 +147,7 @@ describe('eth', () => {
     )
   })
 
-  describe('createEthereumWalletSigner', () => {
+  describe('makeEthereumWalletSigner', () => {
     const dataToSignBytes = hexToBytes('2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae' as HexString)
     const dataToSignWithHelpers = wrapBytesWithHelpers(dataToSignBytes)
     const expectedSignatureHex = '0x336d24afef78c5883b96ad9a62552a8db3d236105cb059ddd04dc49680869dc16234f6852c277087f025d4114c4fac6b40295ecffd1194a84cdb91bd571769491b' as HexString
@@ -185,8 +185,8 @@ describe('eth', () => {
         jsonrpc: '2.0',
         method: 'personal_sign',
         params: [
-          '0xf1B07aC6E91A423d9c3c834cc9d938E89E19334a',
           '0x2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
+          '0xf1B07aC6E91A423d9c3c834cc9d938E89E19334a',
         ],
       })
     })

--- a/test/utils/eth.spec.ts
+++ b/test/utils/eth.spec.ts
@@ -205,8 +205,8 @@ describe('eth', () => {
         jsonrpc: '2.0',
         method: 'personal_sign',
         params: [
-          '0xf1B07aC6E91A423d9c3c834cc9d938E89E19334a',
           '0x2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
+          '0xf1B07aC6E91A423d9c3c834cc9d938E89E19334a',
         ],
       })
     })

--- a/test/utils/eth.spec.ts
+++ b/test/utils/eth.spec.ts
@@ -1,6 +1,6 @@
 /* eslint @typescript-eslint/no-empty-function: 0 */
 import {
-  createEthereumWalletSigner,
+  makeEthereumWalletSigner,
   ethToSwarmAddress,
   fromLittleEndian,
   isHexEthAddress,
@@ -153,18 +153,18 @@ describe('eth', () => {
     const expectedSignatureHex = '0x336d24afef78c5883b96ad9a62552a8db3d236105cb059ddd04dc49680869dc16234f6852c277087f025d4114c4fac6b40295ecffd1194a84cdb91bd571769491b' as HexString
 
     it('should detect valid interface', async () => {
-      await expect(createEthereumWalletSigner({})).rejects.toThrow()
-      await expect(createEthereumWalletSigner(('' as unknown) as JsonRPC)).rejects.toThrow(TypeError)
-      await expect(createEthereumWalletSigner((1 as unknown) as JsonRPC)).rejects.toThrow(TypeError)
-      await expect(createEthereumWalletSigner((null as unknown) as JsonRPC)).rejects.toThrow(TypeError)
-      await expect(createEthereumWalletSigner((undefined as unknown) as JsonRPC)).rejects.toThrow(TypeError)
+      await expect(makeEthereumWalletSigner({})).rejects.toThrow()
+      await expect(makeEthereumWalletSigner(('' as unknown) as JsonRPC)).rejects.toThrow(TypeError)
+      await expect(makeEthereumWalletSigner((1 as unknown) as JsonRPC)).rejects.toThrow(TypeError)
+      await expect(makeEthereumWalletSigner((null as unknown) as JsonRPC)).rejects.toThrow(TypeError)
+      await expect(makeEthereumWalletSigner((undefined as unknown) as JsonRPC)).rejects.toThrow(TypeError)
     })
 
     it('should request address if not specified', async () => {
       const providerMock = jest.fn()
       providerMock.mockReturnValue(['0xf1B07aC6E91A423d9c3c834cc9d938E89E19334a'])
 
-      const signer = await createEthereumWalletSigner({ request: providerMock } as JsonRPC)
+      const signer = await makeEthereumWalletSigner({ request: providerMock } as JsonRPC)
 
       expect(signer.address).toEqual(hexToBytes('f1B07aC6E91A423d9c3c834cc9d938E89E19334a'))
       expect(providerMock.mock.calls.length).toEqual(1)
@@ -175,7 +175,7 @@ describe('eth', () => {
       const providerMock = jest.fn()
       providerMock.mockReturnValue(expectedSignatureHex)
 
-      const signer = await createEthereumWalletSigner(
+      const signer = await makeEthereumWalletSigner(
         { request: providerMock } as JsonRPC,
         '0xf1B07aC6E91A423d9c3c834cc9d938E89E19334a',
       )
@@ -195,7 +195,7 @@ describe('eth', () => {
       const providerMock = jest.fn()
       providerMock.mockReturnValue(expectedSignatureHex)
 
-      const signer = await createEthereumWalletSigner(
+      const signer = await makeEthereumWalletSigner(
         { request: providerMock } as JsonRPC,
         'f1B07aC6E91A423d9c3c834cc9d938E89E19334a',
       )
@@ -216,7 +216,7 @@ describe('eth', () => {
       providerMock.mockReturnValue(expectedSignatureHex)
 
       await expect(
-        createEthereumWalletSigner({ request: providerMock } as JsonRPC, '0x307aC6E91A423d9c3c834cc9d938E89E19334a'),
+        makeEthereumWalletSigner({ request: providerMock } as JsonRPC, '0x307aC6E91A423d9c3c834cc9d938E89E19334a'),
       ).rejects.toThrow(TypeError)
     })
   })


### PR DESCRIPTION
Currently, the target of the PR is `feat/improved-signer` as I was not able to merge the original PR. I will rebase it once it is merged.

It is a draft as I will verify its functionality on the Metamask signing example first.