### PR TITLE
test: increased timeouts for tests testing failure and big files

### DIFF
--- a/test/bee.sh
+++ b/test/bee.sh
@@ -56,7 +56,7 @@ log_queen() {
 
 # Init variables
 EPHEMERAL=false
-WORKERS=2
+WORKERS=4
 QUEEN_CONTAINER_NAME="bee-queen-test"
 WORKER_CONTAINER_NAME="bee-worker-test"
 QUEEN_CONTAINER_IN_DOCKER=`docker container ls -qaf name=$QUEEN_CONTAINER_NAME`

--- a/test/bee.sh
+++ b/test/bee.sh
@@ -11,12 +11,12 @@ COMMANDS:
     stop                        stop Bee cluster
 PARAMETERS:
     --ephemeral                 create ephemeral container for bee-client. Data won't be persisted.
-    --workers=number            all Bee nodes in the test environment. Default is 2.
+    --workers=number            all Bee nodes in the test environment. Default is 4.
     --port-maps=number          map ports of the cluster nodes to the hosting machine in the following manner:
                                 1. 1633:1635
                                 2. 11633:11635
                                 3. 21633:21635 (...)
-                                number represents the nodes number to map from. Default is 2.
+                                number represents the nodes number to map from. Default is 4.
     --password=string           password for Bee client(s).
     --version=x.y.z             used version of Bee client.
 USAGE

--- a/test/feed/index.spec.ts
+++ b/test/feed/index.spec.ts
@@ -1,6 +1,6 @@
 import { fetchFeedUpdate } from '../../src/modules/feed'
 import { HexString, hexToBytes, makeHexString } from '../../src/utils/hex'
-import { beeUrl, testIdentity } from '../utils'
+import { beeUrl, ERR_TIMEOUT, testIdentity } from '../utils'
 import { ChunkReference, downloadFeedUpdate, findNextIndex, Index, uploadFeedUpdate } from '../../src/feed'
 import { Bytes, verifyBytes } from '../../src/utils/bytes'
 import { makeDefaultSigner, PrivateKey, Signer } from '../../src/chunk/signer'
@@ -41,12 +41,16 @@ describe('feed', () => {
   const signer = makeDefaultSigner(hexToBytes(testIdentity.privateKey) as PrivateKey)
   const topic = '0000000000000000000000000000000000000000000000000000000000000000' as Topic
 
-  test('empty feed update', async () => {
-    const emptyTopic = '1000000000000000000000000000000000000000000000000000000000000000' as Topic
-    const index = await findNextIndex(url, owner, emptyTopic)
+  test(
+    'empty feed update',
+    async () => {
+      const emptyTopic = '1000000000000000000000000000000000000000000000000000000000000000' as Topic
+      const index = await findNextIndex(url, owner, emptyTopic)
 
-    expect(index).toEqual('0000000000000000')
-  }, 15000)
+      expect(index).toEqual('0000000000000000')
+    },
+    ERR_TIMEOUT,
+  )
 
   test('feed update', async () => {
     const uploadedChunk = await uploadChunk(url, 0)

--- a/test/modules/bytes.spec.ts
+++ b/test/modules/bytes.spec.ts
@@ -1,5 +1,5 @@
 import * as bytes from '../../src/modules/bytes'
-import { beeUrl, invalidReference } from '../utils'
+import { beeUrl, invalidReference, ERR_TIMEOUT } from '../utils'
 
 const BEE_URL = beeUrl()
 
@@ -13,7 +13,11 @@ describe('modules/bytes', () => {
     expect(Buffer.from(downloadedData).toString()).toEqual(data)
   })
 
-  it('should catch error', async () => {
-    await expect(bytes.download(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
-  })
+  it(
+    'should catch error',
+    async () => {
+      await expect(bytes.download(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+    },
+    ERR_TIMEOUT,
+  )
 })

--- a/test/modules/chunk.spec.ts
+++ b/test/modules/chunk.spec.ts
@@ -1,5 +1,5 @@
 import * as chunk from '../../src/modules/chunk'
-import { beeUrl, invalidReference } from '../utils'
+import { beeUrl, invalidReference, ERR_TIMEOUT } from '../utils'
 
 const BEE_URL = beeUrl()
 
@@ -19,7 +19,11 @@ describe('modules/chunk', () => {
     expect(downloadedData).toEqual(data)
   })
 
-  it('should catch error', async () => {
-    await expect(chunk.download(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
-  })
+  it(
+    'should catch error',
+    async () => {
+      await expect(chunk.download(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+    },
+    ERR_TIMEOUT,
+  )
 })

--- a/test/modules/collection.spec.ts
+++ b/test/modules/collection.spec.ts
@@ -1,6 +1,6 @@
 import * as collection from '../../src/modules/collection'
 import { Collection, ENCRYPTED_REFERENCE_HEX_LENGTH } from '../../src/types'
-import { beeUrl } from '../utils'
+import { beeUrl, BIG_FILE_TIMEOUT } from '../utils'
 
 const BEE_URL = beeUrl()
 
@@ -68,18 +68,22 @@ describe('modules/collection', () => {
     expect(hash.length).toEqual(ENCRYPTED_REFERENCE_HEX_LENGTH)
   })
 
-  it('should upload bigger file', async () => {
-    const directoryStructure: Collection<Uint8Array> = [
-      {
-        path: '0',
-        data: new Uint8Array(32 * 1024 * 1024),
-      },
-    ]
+  it(
+    'should upload bigger file',
+    async () => {
+      const directoryStructure: Collection<Uint8Array> = [
+        {
+          path: '0',
+          data: new Uint8Array(32 * 1024 * 1024),
+        },
+      ]
 
-    const response = await collection.upload(BEE_URL, directoryStructure)
+      const response = await collection.upload(BEE_URL, directoryStructure)
 
-    expect(typeof response).toEqual('string')
-  }, 20000)
+      expect(typeof response).toEqual('string')
+    },
+    BIG_FILE_TIMEOUT,
+  )
 
   it('should throw error when the upload url is not set', async () => {
     await expect(

--- a/test/modules/feed.spec.ts
+++ b/test/modules/feed.spec.ts
@@ -1,6 +1,6 @@
 import { createFeedManifest, fetchFeedUpdate } from '../../src/modules/feed'
 import { HexString, hexToBytes, makeHexString } from '../../src/utils/hex'
-import { beeUrl, testIdentity, tryDeleteChunkFromLocalStorage } from '../utils'
+import { beeUrl, ERR_TIMEOUT, testIdentity, tryDeleteChunkFromLocalStorage } from '../utils'
 import { upload as uploadSOC } from '../../src/modules/soc'
 import type { Topic } from '../../src/feed/topic'
 
@@ -16,12 +16,16 @@ describe('modules/feed', () => {
     expect(response).toEqual(reference)
   })
 
-  test('empty feed update', async () => {
-    const emptyTopic = '1000000000000000000000000000000000000000000000000000000000000000' as Topic
-    const feedUpdate = fetchFeedUpdate(url, owner, emptyTopic)
+  test(
+    'empty feed update',
+    async () => {
+      const emptyTopic = '1000000000000000000000000000000000000000000000000000000000000000' as Topic
+      const feedUpdate = fetchFeedUpdate(url, owner, emptyTopic)
 
-    await expect(feedUpdate).rejects.toThrow('Not Found')
-  }, 15000)
+      await expect(feedUpdate).rejects.toThrow('Not Found')
+    },
+    ERR_TIMEOUT,
+  )
 
   test('one feed update', async () => {
     const oneUpdateTopic = '2000000000000000000000000000000000000000000000000000000000000000' as Topic

--- a/test/modules/file.spec.ts
+++ b/test/modules/file.spec.ts
@@ -1,6 +1,6 @@
 import * as file from '../../src/modules/file'
 import * as tag from '../../src/modules/tag'
-import { beeUrl, createReadable, invalidReference, randomByteArray } from '../utils'
+import { beeUrl, BIG_FILE_TIMEOUT, createReadable, ERR_TIMEOUT, invalidReference, randomByteArray } from '../utils'
 
 const BEE_URL = beeUrl()
 
@@ -49,14 +49,22 @@ describe('modules/file', () => {
     expect(tag2.processed).toEqual(5)
   }, 5000)
 
-  it('should catch error', async () => {
-    await expect(file.download(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
-  })
+  it(
+    'should catch error',
+    async () => {
+      await expect(file.download(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+    },
+    ERR_TIMEOUT,
+  )
 
-  it('should upload bigger file', async () => {
-    const data = new Uint8Array(32 * 1024 * 1024)
-    const response = await file.upload(BEE_URL, data)
+  it(
+    'should upload bigger file',
+    async () => {
+      const data = new Uint8Array(32 * 1024 * 1024)
+      const response = await file.upload(BEE_URL, data)
 
-    expect(typeof response).toEqual('string')
-  }, 20000)
+      expect(typeof response).toEqual('string')
+    },
+    BIG_FILE_TIMEOUT,
+  )
 })

--- a/test/modules/pinning.spec.ts
+++ b/test/modules/pinning.spec.ts
@@ -3,7 +3,15 @@ import * as file from '../../src/modules/file'
 import * as collection from '../../src/modules/collection'
 import * as bytes from '../../src/modules/bytes'
 import * as chunk from '../../src/modules/chunk'
-import { beeUrl, invalidReference, okResponse, randomByteArray, testChunkData, testChunkHash } from '../utils'
+import {
+  beeUrl,
+  invalidReference,
+  okResponse,
+  randomByteArray,
+  testChunkData,
+  testChunkHash,
+  ERR_TIMEOUT,
+} from '../utils'
 import { Collection } from '../../src/types'
 
 const BEE_URL = beeUrl()
@@ -26,9 +34,13 @@ describe('modules/pin', () => {
       expect(response).toEqual(okResponse)
     })
 
-    it('should not pin a non-existing file', async () => {
-      await expect(pinning.pinFile(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
-    })
+    it(
+      'should not pin a non-existing file',
+      async () => {
+        await expect(pinning.pinFile(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+      },
+      ERR_TIMEOUT,
+    )
 
     it('should not unpin a non-existing file', async () => {
       await expect(pinning.unpinFile(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
@@ -61,9 +73,13 @@ describe('modules/pin', () => {
       expect(response).toEqual(okResponse)
     })
 
-    it('should not pin a non-existing collections', async () => {
-      await expect(pinning.pinCollection(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
-    })
+    it(
+      'should not pin a non-existing collections',
+      async () => {
+        await expect(pinning.pinCollection(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+      },
+      ERR_TIMEOUT,
+    )
 
     it('should not unpin a non-existing collections', async () => {
       await expect(pinning.unpinCollection(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
@@ -87,9 +103,13 @@ describe('modules/pin', () => {
       expect(response).toEqual(okResponse)
     })
 
-    it('should not pin a non-existing data', async () => {
-      await expect(pinning.pinData(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
-    })
+    it(
+      'should not pin a non-existing data',
+      async () => {
+        await expect(pinning.pinData(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+      },
+      ERR_TIMEOUT,
+    )
 
     it('should not unpin a non-existing data', async () => {
       await expect(pinning.unpinData(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
@@ -113,9 +133,13 @@ describe('modules/pin', () => {
       expect(pinningResponse).toEqual(okResponse)
     })
 
-    it('should not pin a non-existing chunk', async () => {
-      await expect(pinning.pinChunk(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
-    })
+    it(
+      'should not pin a non-existing chunk',
+      async () => {
+        await expect(pinning.pinChunk(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+      },
+      ERR_TIMEOUT,
+    )
 
     it('should not unpin a non-existing chunk', async () => {
       await expect(pinning.unpinChunk(BEE_URL, invalidReference)).rejects.toThrow('Not Found')

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -146,6 +146,9 @@ export const okResponse: BeeResponse = {
   code: 200,
   message: 'OK',
 }
+
+export const ERR_TIMEOUT = 40000
+export const BIG_FILE_TIMEOUT = 100000
 export const PSS_TIMEOUT = 120000
 export const FEED_TIMEOUT = 120000
 


### PR DESCRIPTION
- increase the amount of nodes spawned by `test/bee.sh` script to 5 which matches the CI
- increased timeout for tests with big files (it just takes longer now for some reason - maybe worse performing CI machine)
- increased timeout for tests which test failure (e.g. downloading non existing file, pining non existing collection). All these seem to now hit some internal timeout and probably should be consulted with Bee devs

Mind you, the test are probably not run correctly against specific release. #229 should fix it but I wanted to keep these PRs separate