### PR TITLE
feat: expose external types

### DIFF
--- a/src/bee.ts
+++ b/src/bee.ts
@@ -19,18 +19,23 @@ import type {
   CollectionUploadOptions,
   FileUploadOptions,
   Data,
+  Signer,
+  FeedReader,
+  FeedWriter,
+  SOCWriter,
+  SOCReader,
+  Topic,
   BeeOptions,
 } from './types'
 import { BeeError } from './utils/error'
 import { prepareWebsocketData } from './utils/data'
 import { fileArrayBuffer, isFile } from './utils/file'
 import { AxiosRequestConfig } from 'axios'
-import { FeedReader, FeedWriter, makeFeedReader, makeFeedWriter } from './feed'
+import { makeFeedReader, makeFeedWriter } from './feed'
 import { makeSigner } from './chunk/signer'
 import { assertIsFeedType, FeedType } from './feed/type'
-import { Signer } from './chunk/signer'
-import { downloadSingleOwnerChunk, uploadSingleOwnerChunkData, SOCReader, SOCWriter } from './chunk/soc'
-import { Topic, makeTopic, makeTopicFromString } from './feed/topic'
+import { downloadSingleOwnerChunk, uploadSingleOwnerChunkData } from './chunk/soc'
+import { makeTopic, makeTopicFromString } from './feed/topic'
 import { createFeedManifest } from './modules/feed'
 import { assertBeeUrl, stripLastSlash } from './utils/url'
 import { EthAddress, makeEthAddress, makeHexEthAddress } from './utils/eth'

--- a/src/chunk/soc.ts
+++ b/src/chunk/soc.ts
@@ -1,12 +1,12 @@
 import { Bytes, bytesAtOffset, bytesEqual, flexBytesAtOffset, verifyBytesAtOffset } from '../utils/bytes'
 import { bmtHash } from './bmt'
-import { recoverAddress, sign, Signature, Signer } from './signer'
+import { recoverAddress, sign } from './signer'
 import { keccak256Hash } from '../utils/hash'
 import { SPAN_SIZE } from './span'
 import { serializeBytes } from './serialize'
 import { BeeError } from '../utils/error'
 import { Chunk, ChunkAddress, makeContentAddressedChunk, MAX_PAYLOAD_SIZE, MIN_PAYLOAD_SIZE, verifyChunk } from './cac'
-import { ReferenceResponse, UploadOptions } from '../types'
+import { ReferenceResponse, UploadOptions, Signature, Signer } from '../types'
 import { bytesToHex } from '../utils/hex'
 import * as socAPI from '../modules/soc'
 import * as chunkAPI from '../modules/chunk'
@@ -34,32 +34,6 @@ export interface SingleOwnerChunk extends Chunk {
   identifier: () => Identifier
   signature: () => Signature
   owner: () => EthAddress
-}
-
-/**
- * Interface for downloading single owner chunks
- */
-export interface SOCReader {
-  /**
-   * Downloads a single owner chunk
-   *
-   * @param identifier  The identifier of the chunk
-   */
-  download: (identifier: Identifier) => Promise<SingleOwnerChunk>
-}
-
-/**
- * Interface for downloading and uploading single owner chunks
- */
-export interface SOCWriter extends SOCReader {
-  /**
-   * Uploads a single owner chunk
-   *
-   * @param identifier  The identifier of the chunk
-   * @param data        The chunk payload data
-   * @param options     Upload options
-   */
-  upload: (identifier: Identifier, data: Uint8Array, options?: UploadOptions) => Promise<ReferenceResponse>
 }
 
 function recoverChunkOwner(data: Uint8Array): EthAddress {

--- a/src/feed/index.ts
+++ b/src/feed/index.ts
@@ -1,7 +1,7 @@
 import { keccak256Hash } from '../utils/hash'
 import { serializeBytes } from '../chunk/serialize'
 import { Identifier, uploadSingleOwnerChunkData, verifySingleOwnerChunk } from '../chunk/soc'
-import { FeedUpdateOptions, fetchFeedUpdate, FetchFeedUpdateResponse } from '../modules/feed'
+import { FeedUpdateOptions, fetchFeedUpdate } from '../modules/feed'
 import {
   REFERENCE_HEX_LENGTH,
   Reference,
@@ -10,6 +10,10 @@ import {
   ENCRYPTED_REFERENCE_HEX_LENGTH,
   ENCRYPTED_REFERENCE_BYTES_LENGTH,
   REFERENCE_BYTES_LENGTH,
+  Signer,
+  FeedReader,
+  FeedWriter,
+  Topic,
 } from '../types'
 import { Bytes, makeBytes, verifyBytesAtOffset } from '../utils/bytes'
 import { BeeResponseError } from '../utils/error'
@@ -18,8 +22,6 @@ import { readUint64BigEndian, writeUint64BigEndian } from '../utils/uint64'
 import * as chunkAPI from '../modules/chunk'
 import { EthAddress, HexEthAddress, makeHexEthAddress } from '../utils/eth'
 
-import type { Signer } from '../chunk/signer'
-import type { Topic } from './topic'
 import type { FeedType } from './type'
 
 const TIMESTAMP_PAYLOAD_OFFSET = 0
@@ -45,34 +47,6 @@ export type ChunkReference = PlainChunkReference | EncryptedChunkReference
 export interface FeedUpdate {
   timestamp: number
   reference: ChunkReference
-}
-
-/**
- * FeedReader is an interface for downloading feed updates
- */
-export interface FeedReader {
-  readonly type: FeedType
-  readonly owner: HexEthAddress
-  readonly topic: Topic
-  /**
-   * Download the latest feed update
-   */
-  download(options?: FeedUpdateOptions): Promise<FetchFeedUpdateResponse>
-}
-
-/**
- * FeedWriter is an interface for updating feeds
- */
-export interface FeedWriter extends FeedReader {
-  /**
-   * Upload a new feed update
-   *
-   * @param reference The reference to be stored in the new update
-   * @param options   Additional options like `at`
-   *
-   * @returns The reference of the new update
-   */
-  upload(reference: ChunkReference | Reference, options?: FeedUploadOptions): Promise<ReferenceResponse>
 }
 
 export function isEpoch(epoch: unknown): epoch is Epoch {

--- a/src/feed/topic.ts
+++ b/src/feed/topic.ts
@@ -1,11 +1,7 @@
 import { keccak256Hash } from '../utils/hash'
 import { verifyBytes } from '../utils/bytes'
-import { HexString, makeHexString, bytesToHex } from '../utils/hex'
-
-export const TOPIC_BYTES_LENGTH = 32
-export const TOPIC_HEX_LENGTH = 64
-
-export type Topic = HexString<typeof TOPIC_HEX_LENGTH>
+import { makeHexString, bytesToHex } from '../utils/hex'
+import { Topic, TOPIC_BYTES_LENGTH, TOPIC_HEX_LENGTH } from '../types'
 
 export function makeTopic(topic: Uint8Array | string): Topic {
   if (typeof topic === 'string') {

--- a/src/modules/feed.ts
+++ b/src/modules/feed.ts
@@ -1,8 +1,7 @@
-import { Dictionary, Reference, ReferenceResponse } from '../types'
+import { Dictionary, Reference, ReferenceResponse, Topic } from '../types'
 import { safeAxios } from '../utils/safeAxios'
 import { FeedType } from '../feed/type'
 import { HexEthAddress } from '../utils/eth'
-import { Topic } from '../feed/topic'
 
 const feedEndpoint = '/feeds'
 

--- a/src/utils/eth.ts
+++ b/src/utils/eth.ts
@@ -1,8 +1,7 @@
 import { keccak256, sha3_256 } from 'js-sha3'
-import { BrandedString, Data } from '../types'
+import { BrandedString, Data, Signer } from '../types'
 import { HexString, hexToBytes, intToHex, makeHexString, assertHexString } from './hex'
 import { Bytes, verifyBytes } from './bytes'
-import { Signer } from '../chunk/signer'
 
 export type OverlayAddress = BrandedString<'OverlayAddress'>
 export type EthAddress = Bytes<20>

--- a/test/feed/index.spec.ts
+++ b/test/feed/index.spec.ts
@@ -3,7 +3,7 @@ import { HexString, hexToBytes, makeHexString } from '../../src/utils/hex'
 import { beeUrl, ERR_TIMEOUT, testIdentity } from '../utils'
 import { ChunkReference, downloadFeedUpdate, findNextIndex, Index, uploadFeedUpdate } from '../../src/feed'
 import { Bytes, verifyBytes } from '../../src/utils/bytes'
-import { makePrivateKeySigner, PrivateKey, Signer } from '../../src/chunk/signer'
+import { makePrivateKeySigner, PrivateKeyBytes, Signer } from '../../src/chunk/signer'
 import { makeContentAddressedChunk } from '../../src/chunk/cac'
 import * as chunkAPI from '../../src/modules/chunk'
 import { Topic } from '../../src/feed/topic'
@@ -38,7 +38,7 @@ async function tryUploadFeedUpdate(url: string, signer: Signer, topic: Topic, in
 describe('feed', () => {
   const url = beeUrl()
   const owner = makeHexString(testIdentity.address, 40)
-  const signer = makePrivateKeySigner(hexToBytes(testIdentity.privateKey) as PrivateKey)
+  const signer = makePrivateKeySigner(hexToBytes(testIdentity.privateKey) as PrivateKeyBytes)
   const topic = '0000000000000000000000000000000000000000000000000000000000000000' as Topic
 
   test(


### PR DESCRIPTION
Closes #214 

This moves several types spread around files into `types/index.ts` as this is exposed on root level and hence is accessible to user, but more importantly it is exposed to `typedoc` generation process so these types will be documented in API Reference.