### PR TITLE
feat: get all published Bee versions from github

### DIFF
--- a/src/bee-debug.ts
+++ b/src/bee-debug.ts
@@ -23,6 +23,7 @@ import type {
   PingResponse,
   Health,
   NodeAddresses,
+  BeeVersion,
 } from './types'
 import { assertBeeUrl, stripLastSlash } from './utils/url'
 import { assertInteger } from './utils/type'
@@ -42,6 +43,24 @@ export class BeeDebug {
     // which could lead to double slash in URL to which Bee responds with
     // unnecessary redirects.
     this.url = stripLastSlash(url)
+  }
+
+  /**
+   * Get all published Bee versions from github
+   *
+   * @returns List of published and released Bee versions
+   */
+  static getBeeVersions(): Promise<BeeVersion[]> {
+    return status.getBeeVersions()
+  }
+
+  /**
+   * Get latest released Bee versions from github
+   *
+   * @returns Latest released Bee version
+   */
+  static getBeeVersionLatest(): Promise<BeeVersion> {
+    return status.getBeeVersionLatest()
   }
 
   getNodeAddresses(): Promise<NodeAddresses> {
@@ -208,6 +227,13 @@ export class BeeDebug {
     return settlements.getAllSettlements(this.url)
   }
 
+  /**
+   * Get health of node
+   *
+   * @param url Bee debug URL
+   *
+   * @returns Health of the bee node and version
+   */
   getHealth(): Promise<Health> {
     return status.getHealth(this.url)
   }

--- a/src/modules/debug/status.ts
+++ b/src/modules/debug/status.ts
@@ -1,10 +1,14 @@
 import { safeAxios } from '../../utils/safeAxios'
-import type { Health } from '../../types/debug'
+import type { Health, BeeVersion } from '../../types/debug'
+
+const GITHUB_API_URL = 'https://api.github.com/repos/ethersphere/bee'
 
 /**
  * Get health of node
  *
  * @param url Bee debug URL
+ *
+ * @returns Health of the bee node and version
  */
 export async function getHealth(url: string): Promise<Health> | never {
   const response = await safeAxios<Health>({
@@ -14,4 +18,44 @@ export async function getHealth(url: string): Promise<Health> | never {
   })
 
   return response.data
+}
+
+interface GithubReleaseResponse {
+  html_url: string
+  tag_name: string
+  draft: boolean
+  prerelease: boolean
+  published_at: string
+}
+
+/**
+ * Get all published Bee versions from github
+ *
+ * @returns List of published and released Bee versions
+ */
+export async function getBeeVersions(): Promise<BeeVersion[]> {
+  const response = await safeAxios<GithubReleaseResponse[]>({
+    method: 'get',
+    url: `${GITHUB_API_URL}/releases`,
+    responseType: 'json',
+  })
+
+  return response.data
+    .filter(v => !v.prerelease && !v.draft) // we want only published versions
+    .map(v => ({ version: v.tag_name, date: v.published_at, url: v.html_url }))
+}
+
+/**
+ * Get latest released Bee versions from github
+ *
+ * @returns Latest released Bee version
+ */
+export async function getBeeVersionLatest(): Promise<BeeVersion> {
+  const response = await safeAxios<GithubReleaseResponse>({
+    method: 'get',
+    url: `${GITHUB_API_URL}/releases/latest`,
+    responseType: 'json',
+  })
+
+  return { version: response.data.tag_name, date: response.data.published_at, url: response.data.html_url }
 }

--- a/src/types/debug.ts
+++ b/src/types/debug.ts
@@ -87,6 +87,11 @@ export interface Health {
   status: 'ok'
   version: string
 }
+export interface BeeVersion {
+  version: string
+  date: string
+  url: string
+}
 
 export interface RemovePeerResponse {
   message: string

--- a/test/modules/debug/status.spec.ts
+++ b/test/modules/debug/status.spec.ts
@@ -1,4 +1,5 @@
-import { getHealth } from '../../../src/modules/debug/status'
+import { getHealth, getBeeVersions, getBeeVersionLatest } from '../../../src/modules/debug/status'
+import { isValidBeeUrl } from '../../../src/utils/url'
 import { beeDebugUrl } from '../../utils'
 
 const BEE_DEBUG_URL = beeDebugUrl()
@@ -9,6 +10,26 @@ describe('modules/status', () => {
 
     expect(health.status).toBe('ok')
     // Matches both versions like 0.5.3-c423a39c and 0.5.3
-    expect(health.version).toMatch(/\d+\.\d+\.\d+(-[0-9a-f]+)?/i)
+    expect(health.version).toMatch(/^\d+\.\d+\.\d+(-[0-9a-f]+)?$/i)
+  })
+
+  test('getBeeVersions', async () => {
+    const versions = await getBeeVersions()
+
+    expect(Array.isArray(versions)).toBeTruthy()
+
+    versions.forEach(v => {
+      expect(v.version).toMatch(/^v\d+\.\d+\.\d+$/i)
+      expect(Date.parse(v.date) !== NaN).toBeTruthy()
+      expect(isValidBeeUrl(v.url)).toBeTruthy()
+    })
+  })
+
+  test('getBeeVersionLatest', async () => {
+    const v = await getBeeVersionLatest()
+
+    expect(v.version).toMatch(/^v\d+\.\d+\.\d+$/i)
+    expect(Date.parse(v.date) !== NaN).toBeTruthy()
+    expect(isValidBeeUrl(v.url)).toBeTruthy()
   })
 })


### PR DESCRIPTION
We talked about this briefly today in daily so I decided to give it a try and implement it. Added two static functions to the BeeDebug 
 class:
```ts
BeeDebug.getBeeVersions() // returns array of all Bee versions published to github
BeeDebug.getBeeVersionLatest() // returns latest Bee version published to github
```

Let's discuss here, I'm sure this will be opinionated feature :)