### PR TITLE
feat: support multiple bee-js versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x, 14.x, 15.x]
-        bee-version: [0.5.2, 0.5.3]
+        bee-version: [0.5.3]
 
     steps:
       - name: Checkout
@@ -92,7 +92,7 @@ jobs:
     strategy:
       matrix:
         node-version: [14.x]
-        bee-version: [0.5.2, 0.5.3]
+        bee-version: [0.5.3]
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,6 @@ on:
 
 
 env:
-  BEE_VERSION: '0.5.3'
   REPLICA: 5
   BEE_API_URL: 'http://bee-0.localhost'
   BEE_PEER_API_URL: 'http://bee-1.localhost'
@@ -23,6 +22,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x, 14.x, 15.x]
+        bee-version: [0.5.2, 0.5.3]
 
     steps:
       - name: Checkout
@@ -42,7 +42,7 @@ jobs:
           export URL=$(curl -s https://api.github.com/repos/ethersphere/bee-local/releases/latest | jq -r .tarball_url)
           curl -Ls ${URL} -o bee-local.tar.gz
           tar --strip-components=1 --wildcards -xzf bee-local.tar.gz ethersphere-bee-local-*/{beeinfra.sh,helm-values,hack}
-          sed -i 's/IMAGE_TAG="latest"/IMAGE_TAG='\"${BEE_VERSION}\"'/' beeinfra.sh
+          sed -i 's/IMAGE_TAG="latest"/IMAGE_TAG='\"${{ matrix.bee-version }}\"'/' beeinfra.sh
       - name: Install latest beekeeper
         run: |
           export TAG=$(curl -s https://api.github.com/repos/ethersphere/beekeeper/releases/latest | jq -r .tag_name)
@@ -65,10 +65,10 @@ jobs:
         id: cache-npm
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.OS }}-node-${{ matrix.node }}-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-${{ matrix.node }}-
+            ${{ runner.OS }}-node-${{ matrix.node-version }}-${{ env.cache-name }}-
+            ${{ runner.OS }}-node-${{ matrix.node-version }}-
 
       - name: Install npm deps
         if: steps.cache-npm.outputs.cache-hit != 'true'
@@ -92,6 +92,7 @@ jobs:
     strategy:
       matrix:
         node-version: [14.x]
+        bee-version: [0.5.2, 0.5.3]
 
     steps:
       - name: Checkout
@@ -106,7 +107,7 @@ jobs:
           export URL=$(curl -s https://api.github.com/repos/ethersphere/bee-local/releases/latest | jq -r .tarball_url)
           curl -Ls ${URL} -o bee-local.tar.gz
           tar --strip-components=1 --wildcards -xzf bee-local.tar.gz ethersphere-bee-local-*/{beeinfra.sh,helm-values,hack}
-          sed -i 's/IMAGE_TAG="latest"/IMAGE_TAG='\"${BEE_VERSION}\"'/' beeinfra.sh
+          sed -i 's/IMAGE_TAG="latest"/IMAGE_TAG='\"${{ matrix.bee-version }}\"'/' beeinfra.sh
       - name: Install latest beekeeper
         run: |
           export TAG=$(curl -s https://api.github.com/repos/ethersphere/beekeeper/releases/latest | jq -r .tag_name)
@@ -129,10 +130,10 @@ jobs:
         id: cache-npm
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.OS }}-node-${{ matrix.node }}-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-${{ matrix.node }}-
+            ${{ runner.OS }}-node-${{ matrix.node-version }}-${{ env.cache-name }}-
+            ${{ runner.OS }}-node-${{ matrix.node-version }}-
 
       - name: Install npm deps
         if: steps.cache-npm.outputs.cache-hit != 'true'

--- a/src/bee-debug.ts
+++ b/src/bee-debug.ts
@@ -211,4 +211,15 @@ export class BeeDebug {
   getHealth(): Promise<Health> {
     return status.getHealth(this.url)
   }
+
+  /**
+   * Connects to a node and checks if it is a supported Bee version by the bee-js
+   *
+   * @param url Bee debug URL
+   *
+   * @returns true if the Bee node version is supported
+   */
+  isSupportedVersion(): Promise<boolean> | never {
+    return status.isSupportedVersion(this.url)
+  }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const SUPPORTED_BEE_VERSIONS = ['0.5.3']

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { BeeDebug } from './bee-debug'
 export * as Utils from './utils/expose'
 export * from './types'
 export * from './utils/error'
+export * from './constants'
 export { Bee, BeeDebug }
 
 // for requrie-like imports

--- a/src/modules/debug/status.ts
+++ b/src/modules/debug/status.ts
@@ -1,5 +1,6 @@
 import { safeAxios } from '../../utils/safeAxios'
 import type { Health } from '../../types/debug'
+import { SUPPORTED_BEE_VERSIONS } from '../../constants'
 
 /**
  * Get health of node
@@ -14,4 +15,20 @@ export async function getHealth(url: string): Promise<Health> | never {
   })
 
   return response.data
+}
+
+/**
+ * Connnects to a node and checks if it is a supported Bee version by the bee-js
+ *
+ * @param url Bee debug URL
+ *
+ * @returns true if the Bee node version is supported
+ */
+export async function isSupportedVersion(url: string): Promise<boolean> | never {
+  const { version } = await getHealth(url)
+
+  // The versions normally look like 0.5.3-c423a39c, this strips the commit hash
+  const versionWithoutCommitHash = version.substring(0, version.indexOf('-'))
+
+  return SUPPORTED_BEE_VERSIONS.includes(versionWithoutCommitHash)
 }

--- a/test/modules/debug/status.spec.ts
+++ b/test/modules/debug/status.spec.ts
@@ -1,4 +1,4 @@
-import { getHealth } from '../../../src/modules/debug/status'
+import { getHealth, isSupportedVersion } from '../../../src/modules/debug/status'
 import { beeDebugUrl } from '../../utils'
 
 const BEE_DEBUG_URL = beeDebugUrl()
@@ -10,5 +10,11 @@ describe('modules/status', () => {
     expect(health.status).toBe('ok')
     // Matches both versions like 0.5.3-c423a39c and 0.5.3
     expect(health.version).toMatch(/\d+\.\d+\.\d+(-[0-9a-f]+)?/i)
+  })
+
+  test('isSupportedVersion', async () => {
+    const isSupported = await isSupportedVersion(BEE_DEBUG_URL)
+
+    expect(isSupported).toBe(true)
   })
 })


### PR DESCRIPTION
**Motivation:**
Since we are no longer version coupled with `bee-js` and because we can expect that soon one `bee-js` version will be compatible with multiple `bee` versions, we need a mechanism to indicate with which `bee` versions is the library compatible. Test should run against all such versions.

**TODO:**
- [ ] in the CI config file `tests.yaml` figure out if we can extract the `bee-version` into some `BEE_SUPPORTED_VERSIONS` variable so that we can just change it in one place
- [x] drop `0.5.2` as it is not compatible

**Questions:**
- Should this be a strong compatibility check testing the commit version as well?