### PR TITLE
style: propagated linter rules that have been changed in swarm-cli and extension

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,9 +13,8 @@ module.exports = {
   },
   plugins: ['jest'],
   rules: {
-    'array-bracket-newline': ['error', { multiline: true }],
+    'array-bracket-newline': ['error', 'consistent'],
     strict: ['error', 'safe'],
-    curly: 'error',
     'block-scoped-var': 'error',
     complexity: 'warn',
     'default-case': 'error',
@@ -73,7 +72,7 @@ module.exports = {
           requireLast: true,
         },
         singleline: {
-          delimiter: 'semi',
+          delimiter: 'comma',
           requireLast: false,
         },
       },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,7 +72,7 @@ module.exports = {
           requireLast: true,
         },
         singleline: {
-          delimiter: 'comma',
+          delimiter: 'semi',
           requireLast: false,
         },
       },

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-    extends: ['@commitlint/config-conventional']
-};
+  extends: ['@commitlint/config-conventional'],
+}


### PR DESCRIPTION
@nugaon raised in the https://github.com/ethersphere/bee-status/pull/35 PR that the linter configuration is different in each project and that the swarm-cli and swarm-extension have newer rules resolving some eslint<->prettier clashes.

1. I tried to update the bee-js rules but now there actually are clashes. Can someone else try?
2. Once clashes are resolved and we agree on the rules here, I'll propagate them to other repos.