### PR TITLE
chore: codeowners specification

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @nugaon @agazso


### PR DESCRIPTION
This enables the GitHub's Code Owners feature. I am not sure if this will actually work as per their documentation this file should be setup by admin/owner of the repo.

https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
