### PR TITLE
refactor!: verify to assert

### DIFF
--- a/src/chunk/cac.ts
+++ b/src/chunk/cac.ts
@@ -45,7 +45,7 @@ export function makeContentAddressedChunk(payloadBytes: Uint8Array): Chunk {
   return {
     data,
     span: () => span,
-    payload: () => flexBytesAtOffset(CAC_PAYLOAD_OFFSET, MIN_PAYLOAD_SIZE, MAX_PAYLOAD_SIZE, data),
+    payload: () => flexBytesAtOffset(data, CAC_PAYLOAD_OFFSET, MIN_PAYLOAD_SIZE, MAX_PAYLOAD_SIZE),
     address: () => bmtHash(data),
   }
 }

--- a/src/chunk/cac.ts
+++ b/src/chunk/cac.ts
@@ -1,7 +1,7 @@
 import { BrandedType } from '../types'
 import { BeeError } from '../utils/error'
 import { bmtHash } from './bmt'
-import { Bytes, bytesEqual, FlexBytes, flexBytesAtOffset, verifyFlexBytes } from '../utils/bytes'
+import { Bytes, bytesEqual, FlexBytes, flexBytesAtOffset, assertFlexBytes } from '../utils/bytes'
 import { serializeBytes } from './serialize'
 import { makeSpan, SPAN_SIZE } from './span'
 
@@ -39,7 +39,7 @@ type ValidChunkData = BrandedType<Uint8Array, 'ValidChunkData'>
  */
 export function makeContentAddressedChunk(payloadBytes: Uint8Array): Chunk {
   const span = makeSpan(payloadBytes.length)
-  verifyFlexBytes(MIN_PAYLOAD_SIZE, MAX_PAYLOAD_SIZE, payloadBytes)
+  assertFlexBytes(payloadBytes, MIN_PAYLOAD_SIZE, MAX_PAYLOAD_SIZE)
   const data = serializeBytes(span, payloadBytes) as ValidChunkData
 
   return {

--- a/src/chunk/signer.ts
+++ b/src/chunk/signer.ts
@@ -1,6 +1,6 @@
 import { ec, curve } from 'elliptic'
 import { BeeError } from '../utils/error'
-import { Bytes, isBytes, verifyBytes, wrapBytesWithHelpers } from '../utils/bytes'
+import { Bytes, isBytes, assertBytes, wrapBytesWithHelpers } from '../utils/bytes'
 import { keccak256Hash } from '../utils/hash'
 import { hexToBytes, makeHexString } from '../utils/hex'
 import { EthAddress } from '../utils/eth'
@@ -95,7 +95,7 @@ export function assertSigner(signer: unknown): asserts signer is Signer {
 
   const typedSigner = signer as Signer
 
-  if (!isBytes(20, typedSigner.address)) {
+  if (!isBytes(typedSigner.address, 20)) {
     throw new TypeError("Signer's address must be Uint8Array with 20 bytes!")
   }
 
@@ -111,9 +111,9 @@ export function makeSigner(signer: Signer | Uint8Array | string | unknown): Sign
 
     return makePrivateKeySigner(keyBytes)
   } else if (signer instanceof Uint8Array) {
-    const verifiedPrivateKey = verifyBytes(32, signer)
+    assertBytes(signer, 32)
 
-    return makePrivateKeySigner(verifiedPrivateKey)
+    return makePrivateKeySigner(signer)
   }
 
   assertSigner(signer)
@@ -131,7 +131,7 @@ export async function sign(signer: Signer, data: Uint8Array): Promise<Signature>
   }
 
   if (result instanceof Uint8Array) {
-    verifyBytes(SIGNATURE_BYTES_LENGTH, result)
+    assertBytes(result, SIGNATURE_BYTES_LENGTH)
 
     return result
   }

--- a/src/chunk/soc.ts
+++ b/src/chunk/soc.ts
@@ -73,7 +73,7 @@ export function makeSingleOwnerChunkFromData(data: Uint8Array, address: ChunkAdd
 
   const signature = () => bytesAtOffset(data, SOC_SIGNATURE_OFFSET, SIGNATURE_SIZE)
   const span = () => bytesAtOffset(data, SOC_SPAN_OFFSET, SPAN_SIZE)
-  const payload = () => flexBytesAtOffset(SOC_PAYLOAD_OFFSET, MIN_PAYLOAD_SIZE, MAX_PAYLOAD_SIZE, data)
+  const payload = () => flexBytesAtOffset(data, SOC_PAYLOAD_OFFSET, MIN_PAYLOAD_SIZE, MAX_PAYLOAD_SIZE)
 
   return {
     data,

--- a/src/feed/topic.ts
+++ b/src/feed/topic.ts
@@ -1,5 +1,5 @@
 import { keccak256Hash } from '../utils/hash'
-import { verifyBytes } from '../utils/bytes'
+import { assertBytes } from '../utils/bytes'
 import { makeHexString, bytesToHex } from '../utils/hex'
 import { Topic, TOPIC_BYTES_LENGTH, TOPIC_HEX_LENGTH } from '../types'
 
@@ -7,7 +7,7 @@ export function makeTopic(topic: Uint8Array | string): Topic {
   if (typeof topic === 'string') {
     return makeHexString(topic, TOPIC_HEX_LENGTH)
   } else if (topic instanceof Uint8Array) {
-    verifyBytes(TOPIC_BYTES_LENGTH, topic)
+    assertBytes(topic, TOPIC_BYTES_LENGTH)
 
     return bytesToHex(topic, TOPIC_HEX_LENGTH)
   }

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -31,7 +31,7 @@ export interface FlexBytes<Min extends number, Max extends number> extends Uint8
  * @param length  The length of the byte array
  * @param b       The byte array
  */
-export function isBytes<Length extends number>(length: Length, b: Uint8Array): b is Bytes<Length> {
+export function isBytes<Length extends number>(b: unknown, length: Length): b is Bytes<Length> {
   return b instanceof Uint8Array && b.length === length
 }
 
@@ -41,11 +41,10 @@ export function isBytes<Length extends number>(length: Length, b: Uint8Array): b
  * @param length  The specified length
  * @param b       The byte array
  */
-export function verifyBytes<Length extends number>(length: Length, b: Uint8Array): Bytes<Length> | never {
-  if (isBytes(length, b)) {
-    return b
+export function assertBytes<Length extends number>(b: unknown, length: Length): asserts b is Bytes<Length> {
+  if (!isBytes(b, length)) {
+    throw new TypeError(`Parameter is not valid Bytes of length: ${length} !== ${(b as Uint8Array).length}`)
   }
-  throw new Error(`verifyBytes failed, length: ${length} !== ${b.length}`)
 }
 
 /**
@@ -58,9 +57,9 @@ export function verifyBytes<Length extends number>(length: Length, b: Uint8Array
 export function isFlexBytes<Min extends number, Max extends number = Min>(
   min: Min,
   max: Max,
-  b: Uint8Array,
+  b: unknown,
 ): b is FlexBytes<Min, Max> {
-  return b.length >= min && b.length <= max
+  return b instanceof Uint8Array && b.length >= min && b.length <= max
 }
 
 /**
@@ -70,15 +69,16 @@ export function isFlexBytes<Min extends number, Max extends number = Min>(
  * @param max     Maximum size of the array
  * @param b       The byte array
  */
-export function verifyFlexBytes<Min extends number, Max extends number = Min>(
+export function assertFlexBytes<Min extends number, Max extends number = Min>(
+  b: unknown,
   min: Min,
   max: Max,
-  b: Uint8Array,
-): FlexBytes<Min, Max> | never {
-  if (isFlexBytes(min, max, b)) {
-    return b
+): asserts b is FlexBytes<Min, Max> {
+  if (!isFlexBytes(min, max, b)) {
+    throw new TypeError(
+      `Parameter is not valid FlexBytes of  min: ${min}, max: ${max}, length: ${(b as Uint8Array).length}`,
+    )
   }
-  throw new Error(`verifyFlexBytes failed, min: ${min}, max: ${max}, length: ${b.length}`)
 }
 
 /**
@@ -88,8 +88,13 @@ export function verifyFlexBytes<Min extends number, Max extends number = Min>(
  * @param length The length of data to be returned
  * @param data   The original data
  */
-export function bytesAtOffset<Length extends number>(offset: number, length: Length, data: Uint8Array): Bytes<Length> {
-  return data.slice(offset, offset + length) as Bytes<Length>
+export function bytesAtOffset<Length extends number>(data: Uint8Array, offset: number, length: Length): Bytes<Length> {
+  const offsetBytes = data.slice(offset, offset + length) as Bytes<Length>
+
+  // We are returning strongly typed Bytes so we have to verify that length is really what we claim
+  assertBytes<Length>(offsetBytes, length)
+
+  return offsetBytes
 }
 
 /**
@@ -126,21 +131,6 @@ export function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
  */
 export function makeBytes<Length extends number>(length: Length): Bytes<Length> {
   return new Uint8Array(length) as Bytes<Length>
-}
-
-/**
- * Verifies if a byte array has a certain length starting from offset
- *
- * @param offset The offset to start from
- * @param length The length of data to be returned
- * @param data   The original data
- */
-export function verifyBytesAtOffset<Length extends number>(
-  offset: number,
-  length: Length,
-  data: Uint8Array,
-): Bytes<Length> {
-  return verifyBytes(length, bytesAtOffset(offset, length, data))
 }
 
 export function wrapBytesWithHelpers(data: Uint8Array): Data {

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -28,8 +28,8 @@ export interface FlexBytes<Min extends number, Max extends number> extends Uint8
 /**
  * Type guard for Bytes<T> type
  *
- * @param length  The length of the byte array
  * @param b       The byte array
+ * @param length  The length of the byte array
  */
 export function isBytes<Length extends number>(b: unknown, length: Length): b is Bytes<Length> {
   return b instanceof Uint8Array && b.length === length
@@ -38,8 +38,8 @@ export function isBytes<Length extends number>(b: unknown, length: Length): b is
 /**
  * Verifies if a byte array has a certain length
  *
- * @param length  The specified length
  * @param b       The byte array
+ * @param length  The specified length
  */
 export function assertBytes<Length extends number>(b: unknown, length: Length): asserts b is Bytes<Length> {
   if (!isBytes(b, length)) {
@@ -50,14 +50,14 @@ export function assertBytes<Length extends number>(b: unknown, length: Length): 
 /**
  * Type guard for FlexBytes<Min,Max> type
  *
+ * @param b       The byte array
  * @param min     Minimum size of the array
  * @param max     Maximum size of the array
- * @param b       The byte array
  */
 export function isFlexBytes<Min extends number, Max extends number = Min>(
+  b: unknown,
   min: Min,
   max: Max,
-  b: unknown,
 ): b is FlexBytes<Min, Max> {
   return b instanceof Uint8Array && b.length >= min && b.length <= max
 }
@@ -65,16 +65,16 @@ export function isFlexBytes<Min extends number, Max extends number = Min>(
 /**
  * Verifies if a byte array has a certain length between min and max
  *
+ * @param b       The byte array
  * @param min     Minimum size of the array
  * @param max     Maximum size of the array
- * @param b       The byte array
  */
 export function assertFlexBytes<Min extends number, Max extends number = Min>(
   b: unknown,
   min: Min,
   max: Max,
 ): asserts b is FlexBytes<Min, Max> {
-  if (!isFlexBytes(min, max, b)) {
+  if (!isFlexBytes(b, min, max)) {
     throw new TypeError(
       `Parameter is not valid FlexBytes of  min: ${min}, max: ${max}, length: ${(b as Uint8Array).length}`,
     )
@@ -84,9 +84,9 @@ export function assertFlexBytes<Min extends number, Max extends number = Min>(
 /**
  * Return `length` bytes starting from `offset`
  *
+ * @param data   The original data
  * @param offset The offset to start from
  * @param length The length of data to be returned
- * @param data   The original data
  */
 export function bytesAtOffset<Length extends number>(data: Uint8Array, offset: number, length: Length): Bytes<Length> {
   const offsetBytes = data.slice(offset, offset + length) as Bytes<Length>
@@ -100,16 +100,16 @@ export function bytesAtOffset<Length extends number>(data: Uint8Array, offset: n
 /**
  * Return flex bytes starting from `offset`
  *
+ * @param data   The original data
  * @param offset The offset to start from
  * @param _min   The minimum size of the data
  * @param _max   The maximum size of the data
- * @param data   The original data
  */
 export function flexBytesAtOffset<Min extends number, Max extends number>(
+  data: Uint8Array,
   offset: number,
   _min: Min,
   _max: Max,
-  data: Uint8Array,
 ): FlexBytes<Min, Max> {
   return data.slice(offset) as FlexBytes<Min, Max>
 }

--- a/src/utils/eth.ts
+++ b/src/utils/eth.ts
@@ -1,7 +1,7 @@
 import { keccak256, sha3_256 } from 'js-sha3'
 import { BrandedString, Data, Signer } from '../types'
 import { HexString, hexToBytes, intToHex, makeHexString, assertHexString } from './hex'
-import { Bytes, verifyBytes } from './bytes'
+import { Bytes, assertBytes } from './bytes'
 
 export type OverlayAddress = BrandedString<'OverlayAddress'>
 export type EthAddress = Bytes<20>
@@ -13,10 +13,13 @@ export function makeEthAddress(address: EthAddress | Uint8Array | string): EthAd
   if (typeof address === 'string') {
     const hexAddr = makeHexString(address, ETH_ADDR_HEX_LENGTH)
     const ownerBytes = hexToBytes<typeof ETH_ADDR_BYTES_LENGTH>(hexAddr)
+    assertBytes(ownerBytes, ETH_ADDR_BYTES_LENGTH)
 
-    return verifyBytes(ETH_ADDR_BYTES_LENGTH, ownerBytes)
+    return ownerBytes
   } else if (address instanceof Uint8Array) {
-    return verifyBytes(ETH_ADDR_BYTES_LENGTH, address)
+    assertBytes(address, ETH_ADDR_BYTES_LENGTH)
+
+    return address
   }
   throw new TypeError('Invalid EthAddress')
 }

--- a/test/chunk/cac.spec.ts
+++ b/test/chunk/cac.spec.ts
@@ -1,4 +1,4 @@
-import { verifyBytes } from '../../src/utils/bytes'
+import { assertBytes } from '../../src/utils/bytes'
 import { makeContentAddressedChunk, assertValidChunkData } from '../../src/chunk/cac'
 import { beeUrl } from '../utils'
 import { serializeBytes } from '../../src/chunk/serialize'
@@ -18,11 +18,10 @@ describe('cac', () => {
   })
 
   test('content address chunk verification', () => {
-    const validAddress = verifyBytes(32, hexToBytes(contentHash))
-    const invalidAddress = verifyBytes(
-      32,
-      hexToBytes('ca6357a08e317d15ec560fef34e4c45f8f19f01c372aa70f1da72bfa7f1a4335'),
-    )
+    const validAddress = hexToBytes(contentHash)
+    assertBytes(validAddress, 32)
+    const invalidAddress = hexToBytes('ca6357a08e317d15ec560fef34e4c45f8f19f01c372aa70f1da72bfa7f1a4335')
+    assertBytes(invalidAddress, 32)
 
     const data = serializeBytes(makeSpan(payload.length), payload)
 
@@ -40,7 +39,8 @@ describe('cac', () => {
   })
 
   test('download content address chunk', async () => {
-    const address = verifyBytes(32, hexToBytes(contentHash))
+    const address = hexToBytes(contentHash)
+    assertBytes(address, 32)
     const data = await chunkAPI.download(beeUrl(), contentHash)
 
     expect(() => assertValidChunkData(data, address)).not.toThrow()

--- a/test/chunk/signer.spec.ts
+++ b/test/chunk/signer.spec.ts
@@ -1,7 +1,8 @@
-import { Signer, sign, makePrivateKeySigner, makeSigner, recoverAddress, Signature } from '../../src/chunk/signer'
-import { makeBytes, verifyBytes, wrapBytesWithHelpers } from '../../src/utils/bytes'
+import { sign, makePrivateKeySigner, makeSigner, recoverAddress } from '../../src/chunk/signer'
+import { makeBytes, assertBytes, wrapBytesWithHelpers } from '../../src/utils/bytes'
 import { HexString, hexToBytes, bytesToHex } from '../../src/utils/hex'
 import { shorten, testIdentity } from '../utils'
+import type { Signature, Signer } from '../../src/types'
 
 describe('signer', () => {
   const dataToSignBytes = hexToBytes('2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae' as HexString)
@@ -11,7 +12,9 @@ describe('signer', () => {
   const expectedSignatureBytes = hexToBytes(expectedSignatureHex)
 
   test('default signer (same data as Bee Go client)', async () => {
-    const privateKey = verifyBytes(32, hexToBytes(testIdentity.privateKey))
+    const privateKey = hexToBytes(testIdentity.privateKey)
+    assertBytes(privateKey, 32)
+
     const signer = makePrivateKeySigner(privateKey)
     const signature = await signer.sign(dataToSignWithHelpers)
 

--- a/test/chunk/soc.spec.ts
+++ b/test/chunk/soc.spec.ts
@@ -1,5 +1,5 @@
-import { Bytes, verifyBytes } from '../../src/utils/bytes'
-import { makeSingleOwnerChunk, verifySingleOwnerChunk, uploadSingleOwnerChunk } from '../../src/chunk/soc'
+import { Bytes, assertBytes } from '../../src/utils/bytes'
+import { makeSingleOwnerChunk, makeSingleOwnerChunkFromData, uploadSingleOwnerChunk } from '../../src/chunk/soc'
 import { makeContentAddressedChunk } from '../../src/chunk/cac'
 import { beeUrl, testIdentity, tryDeleteChunkFromLocalStorage } from '../utils'
 import { makePrivateKeySigner } from '../../src/chunk/signer'
@@ -7,7 +7,8 @@ import * as chunkAPI from '../../src/modules/chunk'
 import { HexString, hexToBytes, bytesToHex } from '../../src/utils/hex'
 
 describe('soc', () => {
-  const privateKey = verifyBytes(32, hexToBytes(testIdentity.privateKey))
+  const privateKey = hexToBytes(testIdentity.privateKey)
+  assertBytes(privateKey, 32)
   const signer = makePrivateKeySigner(privateKey)
   const payload = new Uint8Array([1, 2, 3])
   const socHash = '9d453ebb73b2fedaaf44ceddcf7a0aa37f3e3d6453fea5841c31f0ea6d61dc85' as HexString
@@ -37,8 +38,9 @@ describe('soc', () => {
 
   test('download single owner chunk', async () => {
     const data = await chunkAPI.download(beeUrl(), socHash)
-    const address = verifyBytes(32, hexToBytes(socHash))
-    const soc = verifySingleOwnerChunk(data, address)
+    const address = hexToBytes(socHash)
+    assertBytes(address, 32)
+    const soc = makeSingleOwnerChunkFromData(data, address)
     const socAddress = soc.address()
 
     expect(socAddress).toEqual(address)

--- a/test/feed/index.spec.ts
+++ b/test/feed/index.spec.ts
@@ -2,11 +2,11 @@ import { fetchFeedUpdate } from '../../src/modules/feed'
 import { HexString, hexToBytes, makeHexString } from '../../src/utils/hex'
 import { beeUrl, ERR_TIMEOUT, testIdentity } from '../utils'
 import { ChunkReference, downloadFeedUpdate, findNextIndex, Index, uploadFeedUpdate } from '../../src/feed'
-import { Bytes, verifyBytes } from '../../src/utils/bytes'
-import { makePrivateKeySigner, PrivateKeyBytes, Signer } from '../../src/chunk/signer'
+import { Bytes, assertBytes } from '../../src/utils/bytes'
+import { makePrivateKeySigner } from '../../src/chunk/signer'
 import { makeContentAddressedChunk } from '../../src/chunk/cac'
 import * as chunkAPI from '../../src/modules/chunk'
-import { Topic } from '../../src/feed/topic'
+import type { PrivateKeyBytes, Signer, Topic } from '../../src/types'
 import { BeeResponseError } from '../../src'
 
 function makeChunk(index: number) {
@@ -64,7 +64,8 @@ describe('feed', () => {
 
   test('multiple updates and lookup', async () => {
     const reference = makeHexString('0000000000000000000000000000000000000000000000000000000000000000', 64)
-    const referenceBytes = verifyBytes(32, hexToBytes(reference))
+    const referenceBytes = hexToBytes(reference)
+    assertBytes(referenceBytes, 32)
     const multipleUpdateTopic = '3000000000000000000000000000000000000000000000000000000000000000' as Topic
 
     const numUpdates = 5

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -4,7 +4,7 @@ import { bytesToHex, HexString } from '../src/utils/hex'
 import { deleteChunkFromLocalStorage } from '../src/modules/debug/chunk'
 import { BeeResponseError } from '../src'
 import { ChunkAddress } from '../src/chunk/cac'
-import { verifyBytes } from '../src/utils/bytes'
+import { assertBytes } from '../src/utils/bytes'
 
 /**
  * Load common own Jest Matchers which can be used to check particular return values.
@@ -125,7 +125,7 @@ export function beeDebugUrl(url: string = beeUrl()): string {
  */
 export async function tryDeleteChunkFromLocalStorage(address: string | ChunkAddress): Promise<void> {
   if (typeof address !== 'string') {
-    verifyBytes(32, address)
+    assertBytes(address, 32)
     address = bytesToHex(address)
   }
 


### PR DESCRIPTION
Closes #211 

This is work I had in progress already since last week, so I have wrapped it up as it was getting rather stale.

I have refactored the `verify*` functions into `assert*` functions. Since this is already breaking change for example thanks to the `verifyBytes()` refactor, I took the liberty and also changed the order of the parameters in some of the functions as I believe that the order should follow two guidelines:

 1. Order of significants
 2. Modifiers should come after the subject. E.g. if we are asserting bytes length, this is basically saying "assert that bytes under variable `data` (first parameter) should have length `20` (second parameter)" instead of the current approach that follows more "assert that length `20` (first parameter) is matching variable `data` (second parameter)

