### PR TITLE
fix!: shape of the LastCashoutActionResponse

### DIFF
--- a/src/types/debug.ts
+++ b/src/types/debug.ts
@@ -40,11 +40,10 @@ export interface CashoutResult {
 
 export interface LastCashoutActionResponse {
   peer: string
-  chequebook: string
-  cumulativePayout: BigInt
-  beneficiary: string
+  lastCashedCheque: Cheque
   transactionHash: string
   result: CashoutResult
+  uncashedAmount: bigint
 }
 
 export interface CashoutResponse {


### PR DESCRIPTION
Fixes #260

**NOTE: Until phase 2 of #249 we can not test this on CI**. Here is a JSON that it returns to me locally:


`http://localhost:1635/chequebook/cashout/dc830656350927d57be37dea90834f79d40cf4d4574746be0129496089d49bfc`
```JSON
{
  "peer": "dc830656350927d57be37dea90834f79d40cf4d4574746be0129496089d49bfc",
  "lastCashedCheque": {
    "beneficiary": "0xD2fCA1F348b35E869490435e6C2eFf3996624D64",
    "chequebook": "0x2689Cc943FEC13655869B716A8F2cAd8C32AdD0B",
    "payout": 178765000000000
  },
  "transactionHash": "0x7a25acca4d248de3f87594f52e78d7f325ddd8428d4abee4468e458b5b8ff94f",
  "result": {
    "recipient": "0x05f26c4838be44528ec6fd4a4a31bb7f39296dfb",
    "lastPayout": 0,
    "bounced": false
  },
  "uncashedAmount": 0
}
```