### PR TITLE
fix: check typings for test folder

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -50,14 +50,8 @@ jobs:
       - name: Dependency check
         run: npm run depcheck
 
-      - name: Build nodejs
-        run: npm run compile:node -- --env mode=production
-
-      - name: Build browser
-        run: npm run compile:browser -- --env mode=production
-
-      - name: Build typings
-        run: npm run compile:types
+      - name: Check typings
+        run: npm run check:types
 
       - name: Build docs
         run: npm run docs

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:unit": "jest --verbose --config=jest.config.ts --selectProjects=node:unit",
     "test:node": "jest --verbose --config=jest.config.ts --selectProjects=node:unit node:integration",
     "test:browser": "npm run test:integration:browser",
-    "check:types": "tsc --project tsconfig.test.json --noEmit",
+    "check:types": "tsc --project tsconfig.test.json",
     "lint": "eslint --fix \"src/**/*.ts\" \"test/**/*.ts\" && prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:check": "eslint \"src/**/*.ts\" \"test/**/*.ts\" && prettier --check \"src/**/*.ts\" \"test/**/*.ts\"",
     "depcheck": "depcheck ."

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:unit": "jest --verbose --config=jest.config.ts --selectProjects=node:unit",
     "test:node": "jest --verbose --config=jest.config.ts --selectProjects=node:unit node:integration",
     "test:browser": "npm run test:integration:browser",
+    "check:types": "tsc --project tsconfig.test.json --noEmit",
     "lint": "eslint --fix \"src/**/*.ts\" \"test/**/*.ts\" && prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:check": "eslint \"src/**/*.ts\" \"test/**/*.ts\" && prettier --check \"src/**/*.ts\" \"test/**/*.ts\"",
     "depcheck": "depcheck ."

--- a/test/integration/modules/debug/connectivity.spec.ts
+++ b/test/integration/modules/debug/connectivity.spec.ts
@@ -43,7 +43,7 @@ describe('modules/debug/connectivity', () => {
     expect(topology.depth).toBeGreaterThanOrEqual(0)
 
     for (let i = 0; i < 16; ++i) {
-      const bin = topology.bins[`bin_${i}`] as Bin
+      const bin = topology.bins[`bin_${i}` as keyof typeof topology.bins]
       expect(bin.population).toBeGreaterThanOrEqual(0)
       expect(bin.connected).toBeGreaterThanOrEqual(0)
       expect(Array.isArray(bin.disconnectedPeers) || bin.disconnectedPeers === null).toBeTruthy()

--- a/test/integration/modules/pss.spec.ts
+++ b/test/integration/modules/pss.spec.ts
@@ -33,7 +33,7 @@ describe('modules/pss', () => {
 
       const ws = pss.subscribe(BEE_URL, topic)
       ws.onmessage = ev => {
-        const receivedMessage = Buffer.from(ev.data).toString()
+        const receivedMessage = Buffer.from(ev.data as string).toString()
 
         // ignore empty messages
         if (receivedMessage.length === 0) {
@@ -61,7 +61,7 @@ describe('modules/pss', () => {
 
       const ws = pss.subscribe(BEE_URL, topic)
       ws.onmessage = ev => {
-        const receivedMessage = Buffer.from(ev.data).toString()
+        const receivedMessage = Buffer.from(ev.data as string).toString()
 
         // ignore empty messages
         if (receivedMessage.length === 0) {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -6,6 +6,18 @@ import { BeeResponseError } from '../src'
 import { ChunkAddress } from '../src/chunk/cac'
 import { assertBytes } from '../src/utils/bytes'
 
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    // We have to adhere to upstream API
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    interface Matchers<R, T = {}> {
+      toBeHashReference(): R
+      toBeBeeResponse(expectedStatusCode: number): R
+    }
+  }
+}
+
 /**
  * Load common own Jest Matchers which can be used to check particular return values.
  */

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src",
+    "test"
+  ]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,5 +3,8 @@
   "include": [
     "src",
     "test"
-  ]
+  ],
+  "compilerOptions": {
+    "noEmit": true
+  }
 }


### PR DESCRIPTION
Creates new npm script `check:types` that runs types check also for test folder. Unfortunately, I had to create a new `tsconfig` file that extends our original one and adds the `test` folder.

I have also removed building of the source code for node and browser from GitHub Workflow because I believe it does not detect anything meaningful and only takes unnecessary time.

Closes #257 