### PR TITLE
test: fixes missed escape character in `test/bee.sh`

### DIFF
--- a/test/bee.sh
+++ b/test/bee.sh
@@ -138,7 +138,7 @@ if [ -z "$QUEEN_CONTAINER_IN_DOCKER" ] || $EPHEMERAL ; then
         --bootnode=$QUEEN_BOOTNODE \
         --swap-enable=false \
         --debug-api-enable \
-        --verbosity=4
+        --verbosity=4 \
         --welcome-message="You have found the queen of the beehive..." \
         --cors-allowed-origins="*" \
         --payment-tolerance=2147483647


### PR DESCRIPTION
just a simple fix so i can through the process, nice work guys ;D