### PR TITLE
chore: define release checklist

### DIFF
--- a/.github/config.yaml
+++ b/.github/config.yaml
@@ -1,3 +1,22 @@
 labels:
   issue: type:issue
   pull-request: type:pull-request
+release:
+  trigger:
+    labels:
+      - 'autorelease: pending'
+  checklist: |
+    ## 🚀 Release checklist
+
+    ### Before release
+
+     - [ ] Ensure the release works with the intended `bee` version
+     - [ ] Verify all the example code works with the release code
+     - [ ] Verify all user documentation is up to date
+     - [ ] Have two approval for this PR
+     - [ ] Write small summary for the release and verify changelog
+
+    ### After release
+
+     - [ ] Update API docs
+     - [ ] Update example's `bee-js` version


### PR DESCRIPTION
This creates release checklist that is passed into release PRs by [bee-runner](https://github.com/ethersphere/bee-runner/pull/5), that we defined as our release process.

The communication points are left out here as it is Attilas responsibility.