### PR TITLE
fix: support address option for getJsonFeed

### DIFF
--- a/src/bee.ts
+++ b/src/bee.ts
@@ -41,11 +41,10 @@ import { downloadSingleOwnerChunk, uploadSingleOwnerChunkData } from './chunk/so
 import { makeTopic, makeTopicFromString } from './feed/topic'
 import { createFeedManifest } from './modules/feed'
 import { assertBeeUrl, stripLastSlash } from './utils/url'
-import { EthAddress, HexEthAddress, makeEthAddress, makeHexEthAddress } from './utils/eth'
+import { EthAddress, makeEthAddress, makeHexEthAddress } from './utils/eth'
 import { wrapBytesWithHelpers } from './utils/bytes'
 import { assertReference } from './utils/type'
 import { setJsonData, getJsonData } from './feed/json'
-import { add } from 'husky'
 
 /**
  * The Bee class provides a way of interacting with the Bee APIs based on the provided url

--- a/src/feed/json.ts
+++ b/src/feed/json.ts
@@ -1,4 +1,4 @@
-import { JsonFeed, FeedWriter, ReferenceResponse, FeedReader, AnyJson } from '../types'
+import { FeedWriter, ReferenceResponse, FeedReader, AnyJson } from '../types'
 import { Bee } from '../bee'
 
 function serializeJson(data: AnyJson): Uint8Array {

--- a/src/feed/json.ts
+++ b/src/feed/json.ts
@@ -12,28 +12,16 @@ function serializeJson(data: AnyJson): Uint8Array {
   }
 }
 
-function getJsonData<T extends AnyJson>(bee: Bee, reader: FeedReader): () => Promise<T> {
-  return async () => {
-    const feedUpdate = await reader.download()
-    const retrievedData = await bee.downloadData(feedUpdate.reference)
+export async function getJsonData<T extends AnyJson>(bee: Bee, reader: FeedReader): Promise<T> {
+  const feedUpdate = await reader.download()
+  const retrievedData = await bee.downloadData(feedUpdate.reference)
 
-    return retrievedData.json() as T
-  }
+  return retrievedData.json() as T
 }
 
-function setJsonData(bee: Bee, writer: FeedWriter): (data: AnyJson) => Promise<ReferenceResponse> {
-  return async (data: AnyJson) => {
-    const serializedData = serializeJson(data)
-    const reference = await bee.uploadData(serializedData)
+export async function setJsonData(bee: Bee, writer: FeedWriter, data: AnyJson): Promise<ReferenceResponse> {
+  const serializedData = serializeJson(data)
+  const reference = await bee.uploadData(serializedData)
 
-    return writer.upload(reference)
-  }
-}
-
-export function makeJsonFeed<T extends AnyJson>(bee: Bee, writer: FeedWriter): JsonFeed<T> {
-  return {
-    writer,
-    get: getJsonData<T>(bee, writer),
-    set: setJsonData(bee, writer),
-  }
+  return writer.upload(reference)
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -148,17 +148,6 @@ export interface FeedReader {
   download(options?: FeedUpdateOptions): Promise<FetchFeedUpdateResponse>
 }
 
-/**
- * Higher level abstraction build on top of Feeds that allow easy setting and getting
- * data from feeds. It works closely with JSON.parse/stringify so all supported data
- * types by that is also supported by this abstraction.
- */
-export interface JsonFeed<T extends AnyJson> {
-  readonly writer: FeedWriter
-  set(data: AnyJson): Promise<ReferenceResponse>
-  get(): Promise<T>
-}
-
 export interface JsonFeedOptions {
   /**
    * Valid only for `get` action, where either this `address` or `signer` has

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -160,6 +160,17 @@ export interface JsonFeed<T extends AnyJson> {
 }
 
 export interface JsonFeedOptions {
+  /**
+   * Valid only for `get` action, where either this `address` or `signer` has
+   * to be specified.
+   */
+  address?: EthAddress | Uint8Array | string
+
+  /**
+   * Custom Signer object or private key in either binary or hex form.
+   * This required for `set` action, and optional for `get` although
+   * if not specified for `get` then `address` option has to be specified.
+   */
   signer?: Signer | Uint8Array | string
   type?: FeedType
 }

--- a/src/utils/eth.ts
+++ b/src/utils/eth.ts
@@ -9,7 +9,7 @@ export type HexEthAddress = HexString<40>
 const ETH_ADDR_BYTES_LENGTH = 20
 const ETH_ADDR_HEX_LENGTH = 40
 
-export function makeEthAddress(address: EthAddress | Uint8Array | string): EthAddress {
+export function makeEthAddress(address: EthAddress | Uint8Array | string | unknown): EthAddress {
   if (typeof address === 'string') {
     const hexAddr = makeHexString(address, ETH_ADDR_HEX_LENGTH)
     const ownerBytes = hexToBytes<typeof ETH_ADDR_BYTES_LENGTH>(hexAddr)
@@ -24,7 +24,7 @@ export function makeEthAddress(address: EthAddress | Uint8Array | string): EthAd
   throw new TypeError('Invalid EthAddress')
 }
 
-export function makeHexEthAddress(address: EthAddress | Uint8Array | string): HexEthAddress {
+export function makeHexEthAddress(address: EthAddress | Uint8Array | string | unknown): HexEthAddress {
   try {
     return makeHexString(address, ETH_ADDR_HEX_LENGTH)
   } catch (e) {

--- a/src/utils/hex.ts
+++ b/src/utils/hex.ts
@@ -30,7 +30,7 @@ export type PrefixedHexString = BrandedType<string, 'PrefixedHexString'>
  * @param input
  * @param len of the resulting HexString WITHOUT prefix!
  */
-export function makeHexString<L extends number>(input: string | number | Uint8Array, len?: L): HexString<L> {
+export function makeHexString<L extends number>(input: string | number | Uint8Array | unknown, len?: L): HexString<L> {
   if (typeof input === 'number') {
     return intToHex<L>(input, len)
   }

--- a/test/integration/bee-class.spec.ts
+++ b/test/integration/bee-class.spec.ts
@@ -15,6 +15,8 @@ import {
   randomByteArray,
   testChunkPayload,
   testIdentity,
+  testJsonHash,
+  testJsonPayload,
   tryDeleteChunkFromLocalStorage,
 } from '../utils'
 import { makeSigner } from '../../src/chunk/signer'
@@ -434,15 +436,15 @@ describe('Bee class', () => {
     it(
       'should set JSON to feed',
       async () => {
-        const data = [{ some: 'object' }]
-        await bee.setJsonFeed(TOPIC, data, { signer: testIdentity.privateKey })
+        await bee.setJsonFeed(TOPIC, testJsonPayload, { signer: testIdentity.privateKey })
 
         const hashedTopic = bee.makeFeedTopic(TOPIC)
         const reader = bee.makeFeedReader('sequence', hashedTopic, testIdentity.address)
         const chunkReferenceResponse = await reader.download()
-        const downloadedData = await bee.downloadData(chunkReferenceResponse.reference)
+        expect(chunkReferenceResponse.reference).toEqual(testJsonHash)
 
-        expect(downloadedData.json()).toEqual(data)
+        const downloadedData = await bee.downloadData(chunkReferenceResponse.reference)
+        expect(downloadedData.json()).toEqual(testJsonPayload)
       },
       FEED_TIMEOUT,
     )

--- a/test/integration/bee-class.spec.ts
+++ b/test/integration/bee-class.spec.ts
@@ -462,5 +462,20 @@ describe('Bee class', () => {
       },
       FEED_TIMEOUT,
     )
+    it(
+      'should get JSON from feed with address',
+      async () => {
+        const data = [{ some: { other: 'object' } }]
+
+        const hashedTopic = bee.makeFeedTopic(TOPIC)
+        const writer = bee.makeFeedWriter('sequence', hashedTopic, testIdentity.privateKey)
+        const dataChunkReference = await bee.uploadData(JSON.stringify(data))
+        await writer.upload(dataChunkReference)
+
+        const fetchedData = await bee.getJsonFeed(TOPIC, { address: testIdentity.address })
+        expect(fetchedData).toEqual(data)
+      },
+      FEED_TIMEOUT,
+    )
   })
 })

--- a/test/unit/bee-class.spec.ts
+++ b/test/unit/bee-class.spec.ts
@@ -1,0 +1,96 @@
+import { assertAllIsDone, downloadDataMock, fetchFeedUpdateMock, MOCK_SERVER_URL } from './nock'
+import { Bee, BeeError, ReferenceResponse } from '../../src'
+import { testIdentity, testJsonHash, testJsonPayload, testJsonStringPayload } from '../utils'
+import { makeTopicFromString } from '../../src/feed/topic'
+
+const TOPIC = 'some=very%nice#topic'
+const HASHED_TOPIC = makeTopicFromString(TOPIC)
+
+describe('Bee class', () => {
+  describe('getJsonFeed', () => {
+    it('should fetch with specified address', async () => {
+      downloadDataMock(testJsonHash).reply(200, testJsonStringPayload)
+      fetchFeedUpdateMock(testIdentity.address, HASHED_TOPIC).reply(200, {
+        reference: testJsonHash,
+      } as ReferenceResponse)
+
+      const bee = new Bee(MOCK_SERVER_URL)
+      const json = await bee.getJsonFeed(TOPIC, { address: testIdentity.address })
+      expect(json).toEqual(testJsonPayload)
+
+      assertAllIsDone()
+    })
+
+    it('should fetch with specified signer private key', async () => {
+      downloadDataMock(testJsonHash).reply(200, testJsonStringPayload)
+      fetchFeedUpdateMock(testIdentity.address, HASHED_TOPIC).reply(200, {
+        reference: testJsonHash,
+      } as ReferenceResponse)
+
+      const bee = new Bee(MOCK_SERVER_URL)
+      const json = await bee.getJsonFeed(TOPIC, { signer: testIdentity.privateKey })
+      expect(json).toEqual(testJsonPayload)
+
+      assertAllIsDone()
+    })
+
+    it('should fetch with default instance signer', async () => {
+      downloadDataMock(testJsonHash).reply(200, testJsonStringPayload)
+      fetchFeedUpdateMock(testIdentity.address, HASHED_TOPIC).reply(200, {
+        reference: testJsonHash,
+      } as ReferenceResponse)
+
+      const bee = new Bee(MOCK_SERVER_URL, { signer: testIdentity.privateKey })
+      const json = await bee.getJsonFeed(TOPIC)
+      expect(json).toEqual(testJsonPayload)
+
+      assertAllIsDone()
+    })
+
+    it('should prioritize address option over default instance signer', async () => {
+      downloadDataMock(testJsonHash).reply(200, testJsonStringPayload)
+      fetchFeedUpdateMock(testIdentity.address, HASHED_TOPIC).reply(200, {
+        reference: testJsonHash,
+      } as ReferenceResponse)
+
+      const bee = new Bee(MOCK_SERVER_URL, {
+        // Some other PK
+        signer: '634fb5a811196d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd',
+      })
+      const json = await bee.getJsonFeed(TOPIC, { address: testIdentity.address })
+      expect(json).toEqual(testJsonPayload)
+
+      assertAllIsDone()
+    })
+
+    it('should prioritize signer option over default instance signer', async () => {
+      downloadDataMock(testJsonHash).reply(200, testJsonStringPayload)
+      fetchFeedUpdateMock(testIdentity.address, HASHED_TOPIC).reply(200, {
+        reference: testJsonHash,
+      } as ReferenceResponse)
+
+      const bee = new Bee(MOCK_SERVER_URL, {
+        // Some other PK
+        signer: '634fb5a811196d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd',
+      })
+      const json = await bee.getJsonFeed(TOPIC, { signer: testIdentity.privateKey })
+      expect(json).toEqual(testJsonPayload)
+
+      assertAllIsDone()
+    })
+
+    it('should fail when both signer and address options are specified', async () => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      await expect(
+        bee.getJsonFeed(TOPIC, { address: testIdentity.address, signer: testIdentity.privateKey }),
+      ).rejects.toThrow()
+    })
+
+    it('should fail if no signer or address is specified', async () => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      await expect(bee.getJsonFeed(TOPIC)).rejects.toThrow()
+    })
+  })
+})

--- a/test/unit/feed/json.spec.ts
+++ b/test/unit/feed/json.spec.ts
@@ -62,7 +62,7 @@ describe('JsonFeed', () => {
   it(`should fail for non-serializable data`, async () => {
     const bee = Substitute.for<Bee>()
     const writer = Substitute.for<FeedWriter>()
-    await expect(setJsonData(bee, writer, (BigInt(123) as unknown) as AnyJson)).resolves.toEqual(FEED_REFERENCE)
+    await expect(setJsonData(bee, writer, (BigInt(123) as unknown) as AnyJson)).rejects.toThrow(TypeError)
 
     const circularReference: CircularReference = { otherData: 123 }
     circularReference.myself = circularReference

--- a/test/unit/feed/json.spec.ts
+++ b/test/unit/feed/json.spec.ts
@@ -1,7 +1,7 @@
 import { Arg, Substitute } from '@fluffy-spoon/substitute'
 import { AnyJson, Bee, FeedWriter, Reference } from '../../../src'
 import { testChunkHash } from '../../utils'
-import { makeJsonFeed } from '../../../src/feed/json'
+import { getJsonData, setJsonData } from '../../../src/feed/json'
 import { FetchFeedUpdateResponse } from '../../../src/modules/feed'
 import { wrapBytesWithHelpers } from '../../../src/utils/bytes'
 
@@ -25,8 +25,7 @@ describe('JsonFeed', () => {
       const writer = Substitute.for<FeedWriter>()
       writer.upload(Arg.all()).resolves(FEED_REFERENCE)
 
-      const jsonFeed = makeJsonFeed(bee, writer)
-      await expect(jsonFeed.set(data as AnyJson)).resolves.toEqual(FEED_REFERENCE)
+      await expect(setJsonData(bee, writer, data as AnyJson)).resolves.toEqual(FEED_REFERENCE)
       bee.received(1).uploadData(expectedBytes)
       writer.received(1).upload(DATA_REFERENCE)
     })
@@ -38,8 +37,7 @@ describe('JsonFeed', () => {
       const writer = Substitute.for<FeedWriter>()
       writer.download().resolves(FEED_REFERENCE)
 
-      const jsonFeed = makeJsonFeed(bee, writer)
-      await expect(jsonFeed.get()).resolves.toEqual(data)
+      await expect(getJsonData(bee, writer)).resolves.toEqual(data)
       bee.received(1).downloadData(FEED_REFERENCE_HASH)
       writer.received(1).download()
     })
@@ -64,8 +62,7 @@ describe('JsonFeed', () => {
   it(`should fail for non-serializable data`, async () => {
     const bee = Substitute.for<Bee>()
     const writer = Substitute.for<FeedWriter>()
-    const feed = makeJsonFeed(bee, writer)
-    await expect(feed.set((BigInt(123) as unknown) as AnyJson)).rejects.toThrow(TypeError)
+    await expect(setJsonData(bee, writer, (BigInt(123) as unknown) as AnyJson)).resolves.toEqual(FEED_REFERENCE)
 
     const circularReference: CircularReference = { otherData: 123 }
     circularReference.myself = circularReference

--- a/test/unit/feed/json.spec.ts
+++ b/test/unit/feed/json.spec.ts
@@ -69,6 +69,6 @@ describe('JsonFeed', () => {
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore: Circular references are detected with TS, so we have to ts-ignore to test it.
-    await expect(feed.set(circularReference)).rejects.toThrow(TypeError)
+    await expect(setJsonData(bee, writer, circularReference)).rejects.toThrow(TypeError)
   })
 })

--- a/test/unit/nock.ts
+++ b/test/unit/nock.ts
@@ -1,0 +1,28 @@
+import nock from 'nock'
+import { HexEthAddress } from '../../src/utils/eth'
+import { Reference } from '../../src/types'
+import { DEFAULT_FEED_TYPE, FeedType } from '../../src/feed/type'
+
+export const MOCK_SERVER_URL = 'http://localhost:12345/'
+
+// Endpoints
+const feedEndpoint = '/feeds'
+const bytesEndpoint = '/bytes'
+
+export function assertAllIsDone(): void {
+  if (!nock.isDone()) {
+    throw new Error('Some expected request was not performed!')
+  }
+}
+
+export function fetchFeedUpdateMock(
+  address: HexEthAddress | string,
+  hashedTopic: string,
+  type: FeedType = DEFAULT_FEED_TYPE,
+): nock.Interceptor {
+  return nock(MOCK_SERVER_URL).get(`${feedEndpoint}/${address}/${hashedTopic}?type=${type}`)
+}
+
+export function downloadDataMock(reference: Reference | string): nock.Interceptor {
+  return nock(MOCK_SERVER_URL).get(`${bytesEndpoint}/${reference}`)
+}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -187,6 +187,10 @@ export const testChunkData = new Uint8Array([...testChunkSpan, ...testChunkPaylo
 // the hash is hardcoded because we would need the bmt hasher otherwise
 export const testChunkHash = 'ca6357a08e317d15ec560fef34e4c45f8f19f01c372aa70f1da72bfa7f1a4338' as Reference
 
+export const testJsonPayload = [{ some: 'object' }]
+export const testJsonStringPayload = JSON.stringify(testJsonPayload)
+export const testJsonHash = '872a858115b8bee4408b1427b49e472883fdc2512d5a8f2d428b97ecc8f7ccfa'
+
 export const testIdentity = {
   privateKey: '634fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd' as HexString,
   publicKey: '03c32bb011339667a487b6c1c35061f15f7edc36aa9a0f8648aba07a4b8bd741b4' as HexString,


### PR DESCRIPTION
This address the shortcoming of design of `getJsonFeed` that required always to have the private key for fetching the data even if it is not required and basically it disallowed to fetch other's users feed data.