### PR TITLE
refactor: address type is strict hexstring

### DIFF
--- a/src/bee-debug.ts
+++ b/src/bee-debug.ts
@@ -25,7 +25,7 @@ import type {
   NodeAddresses,
 } from './types'
 import { assertBeeUrl, stripLastSlash } from './utils/url'
-import { assertInteger } from './utils/type'
+import { assertAddress, assertInteger } from './utils/type'
 
 /**
  * The BeeDebug class provides a way of interacting with the Bee debug APIs based on the provided url
@@ -87,7 +87,9 @@ export class BeeDebug {
    *
    * @param address Swarm address of peer
    */
-  getPeerBalance(address: Address): Promise<PeerBalance> {
+  getPeerBalance(address: Address | string): Promise<PeerBalance> {
+    assertAddress(address)
+
     return balance.getPeerBalance(this.url, address)
   }
 
@@ -103,7 +105,9 @@ export class BeeDebug {
    *
    * @param address Swarm address of peer
    */
-  getPastDueConsumptionPeerBalance(address: Address): Promise<PeerBalance> {
+  getPastDueConsumptionPeerBalance(address: Address | string): Promise<PeerBalance> {
+    assertAddress(address)
+
     return balance.getPastDueConsumptionPeerBalance(this.url, address)
   }
 
@@ -140,7 +144,9 @@ export class BeeDebug {
    *
    * @param address  Swarm address of peer
    */
-  getLastChequesForPeer(address: Address): Promise<LastChequesForPeerResponse> {
+  getLastChequesForPeer(address: Address | string): Promise<LastChequesForPeerResponse> {
+    assertAddress(address)
+
     return chequebook.getLastChequesForPeer(this.url, address)
   }
 
@@ -149,7 +155,9 @@ export class BeeDebug {
    *
    * @param address  Swarm address of peer
    */
-  getLastCashoutAction(address: Address): Promise<LastCashoutActionResponse> {
+  getLastCashoutAction(address: Address | string): Promise<LastCashoutActionResponse> {
+    assertAddress(address)
+
     return chequebook.getLastCashoutAction(this.url, address)
   }
 
@@ -197,7 +205,9 @@ export class BeeDebug {
    *
    * @param address  Swarm address of peer
    */
-  getSettlements(address: Address): Promise<Settlements> {
+  getSettlements(address: Address | string): Promise<Settlements> {
+    assertAddress(address)
+
     return settlements.getSettlements(this.url, address)
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,7 @@ export interface Dictionary<T> {
   [Key: string]: T
 }
 
+export const ADDRESS_HEX_LENGTH = 64
 export const REFERENCE_HEX_LENGTH = 64
 export const ENCRYPTED_REFERENCE_HEX_LENGTH = 128
 export const REFERENCE_BYTES_LENGTH = 32
@@ -21,8 +22,13 @@ export const ENCRYPTED_REFERENCE_BYTES_LENGTH = 64
 export type Reference = HexString<typeof REFERENCE_HEX_LENGTH> | HexString<typeof ENCRYPTED_REFERENCE_HEX_LENGTH>
 export type PublicKey = string
 
-export type Address = string
-export type AddressPrefix = Address
+export type Address = HexString<typeof ADDRESS_HEX_LENGTH>
+
+/**
+ * AddressPrefix is an HexString of length equal or smaller then ADDRESS_HEX_LENGTH.
+ * It represents PSS Address Prefix that is used to define address neighborhood that will receive the PSS message.
+ */
+export type AddressPrefix = HexString
 
 export interface BeeOptions {
   signer?: Signer | Uint8Array | string

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -1,4 +1,4 @@
-import { ENCRYPTED_REFERENCE_HEX_LENGTH, Reference, REFERENCE_HEX_LENGTH } from '../types'
+import { Address, ADDRESS_HEX_LENGTH, ENCRYPTED_REFERENCE_HEX_LENGTH, Reference, REFERENCE_HEX_LENGTH } from '../types'
 import { assertHexString } from './hex'
 
 export function isInteger(value: unknown): value is number | bigint {
@@ -21,4 +21,8 @@ export function assertReference(value: unknown): asserts value is Reference {
   } catch (e) {
     assertHexString(value, ENCRYPTED_REFERENCE_HEX_LENGTH)
   }
+}
+
+export function assertAddress(value: unknown): asserts value is Address {
+  assertHexString(value, ADDRESS_HEX_LENGTH)
 }


### PR DESCRIPTION
Refactor that I need for postage stamp work. Strictly types `Address` type to `HexString`. 