### PR TITLE
refactor: new pinning api

### DIFF
--- a/src/bee.ts
+++ b/src/bee.ts
@@ -28,6 +28,7 @@ import type {
   ReferenceResponse,
   JsonFeedOptions,
   AnyJson,
+  Pin,
 } from './types'
 import { BeeError } from './utils/error'
 import { prepareWebsocketData } from './utils/data'
@@ -205,58 +206,14 @@ export class Bee {
   }
 
   /**
-   * Pin file with given reference
-   *
-   * @param reference Bee file reference
-   */
-  pinFile(reference: Reference | string): Promise<BeeResponse> {
-    assertReference(reference)
-
-    return pinning.pinFile(this.url, reference)
-  }
-
-  /**
-   * Unpin file with given reference
-   *
-   * @param reference Bee file reference
-   */
-  unpinFile(reference: Reference | string): Promise<BeeResponse> {
-    assertReference(reference)
-
-    return pinning.unpinFile(this.url, reference)
-  }
-
-  /**
-   * Pin collection with given reference
-   *
-   * @param reference Bee collection reference
-   */
-  pinCollection(reference: Reference | string): Promise<BeeResponse> {
-    assertReference(reference)
-
-    return pinning.pinCollection(this.url, reference)
-  }
-
-  /**
-   * Unpin collection with given reference
-   *
-   * @param reference Bee collection reference
-   */
-  unpinCollection(reference: Reference | string): Promise<BeeResponse> {
-    assertReference(reference)
-
-    return pinning.unpinCollection(this.url, reference)
-  }
-
-  /**
    * Pin data with given reference
    *
    * @param reference Bee data reference
    */
-  pinData(reference: Reference | string): Promise<BeeResponse> {
+  pin(reference: Reference | string): Promise<BeeResponse> {
     assertReference(reference)
 
-    return pinning.pinData(this.url, reference)
+    return pinning.pin(this.url, reference)
   }
 
   /**
@@ -264,41 +221,17 @@ export class Bee {
    *
    * @param reference Bee data reference
    */
-  unpinData(reference: Reference | string): Promise<BeeResponse> {
+  unpin(reference: Reference | string): Promise<BeeResponse> {
     assertReference(reference)
 
-    return pinning.unpinData(this.url, reference)
+    return pinning.unpin(this.url, reference)
   }
 
   /**
-   * Pin data with given reference
-   *
-   * @param reference Bee data reference
+   * Get list of all pins
    */
-  pinChunk(reference: Reference | string): Promise<BeeResponse> {
-    assertReference(reference)
-
-    return pinning.pinChunk(this.url, reference)
-  }
-
-  /**
-   * Unpin data with given reference
-   *
-   * @param reference Bee data reference
-   */
-  unpinChunk(reference: Reference | string): Promise<BeeResponse> {
-    assertReference(reference)
-
-    return pinning.unpinChunk(this.url, reference)
-  }
-
-  /**
-   * Get list of pinned chunks
-   *
-   * @param options Optional offset and limit of listing
-   */
-  getPinnedChunks(options?: pinning.PinnedChunksOptions): Promise<pinning.PinnedChunks> {
-    return pinning.getPinnedChunks(this.url, options)
+  getAllPins(): Promise<Pin[]> {
+    return pinning.getAllPins(this.url)
   }
 
   /**
@@ -306,22 +239,10 @@ export class Bee {
    *
    * @param reference Bee data reference
    */
-  getChunkPinningStatus(reference: Reference | string): Promise<pinning.PinningStatus> {
+  getPin(reference: Reference | string): Promise<Pin> {
     assertReference(reference)
 
-    return pinning.getChunkPinningStatus(this.url, reference)
-  }
-
-  /**
-   * Update pin counter of chunk with given reference
-   *
-   * @param reference   Bee data reference
-   * @param pinCounter  New value of the pin counter
-   */
-  updateChunkPinCounter(reference: Reference | string, pinCounter: number): Promise<pinning.PinningStatus> {
-    assertReference(reference)
-
-    return pinning.updateChunkPinCounter(this.url, reference, pinCounter)
+    return pinning.getPin(this.url, reference)
   }
 
   /**

--- a/src/modules/pinning.ts
+++ b/src/modules/pinning.ts
@@ -4,7 +4,7 @@ import { safeAxios } from '../utils/safeAxios'
 const PINNING_ENDPOINT = '/pins'
 
 export interface GetAllPinResponse {
-  chunks: Pin[]
+  references: Pin[] | null
 }
 
 /**
@@ -68,5 +68,11 @@ export async function getAllPins(url: string): Promise<Pin[]> {
     url: `${url}${PINNING_ENDPOINT}`,
   })
 
-  return response.data.chunks
+  const result = response.data.references
+
+  if (result === null) {
+    return []
+  }
+
+  return result
 }

--- a/src/modules/pinning.ts
+++ b/src/modules/pinning.ts
@@ -1,185 +1,72 @@
-import type { BeeResponse, Reference } from '../types'
+import type { BeeResponse, Pin, Reference } from '../types'
 import { safeAxios } from '../utils/safeAxios'
 
-enum Endpoint {
-  FILE = '/pin/files',
-  COLLECTION = '/pin/bzz',
-  BYTES = '/pin/bytes',
-  CHUNKS = '/pin/chunks',
-}
+const PINNING_ENDPOINT = '/pins'
 
-export interface PinningStatus {
-  address: string
-  pinCounter: number
-}
-
-export interface PinnedChunks {
-  chunks: PinningStatus[]
-}
-
-async function pinRequest(url: string, method: 'post' | 'delete'): Promise<BeeResponse> {
-  const response = await safeAxios<BeeResponse>({
-    method,
-    responseType: 'json',
-    url,
-  })
-
-  return response.data
-}
-
-function pin(url: string, endpoint: Endpoint, hash: Reference): Promise<BeeResponse> {
-  return pinRequest(`${url}${endpoint}/${hash}`, 'post')
-}
-
-function unpin(url: string, endpoint: Endpoint, hash: Reference): Promise<BeeResponse> {
-  return pinRequest(`${url}${endpoint}/${hash}`, 'delete')
-}
-
-/**
- * Pin file with given reference
- *
- * @param url  Bee URL
- * @param hash Bee file reference
- */
-export function pinFile(url: string, hash: Reference): Promise<BeeResponse> {
-  return pin(url, Endpoint.FILE, hash)
-}
-
-/**
- * Unpin file with given reference
- *
- * @param url  Bee URL
- * @param hash Bee file reference
- */
-export function unpinFile(url: string, hash: Reference): Promise<BeeResponse> {
-  return unpin(url, Endpoint.FILE, hash)
-}
-
-/**
- * Pin collection with given reference
- *
- * @param url  Bee URL
- * @param hash Bee collection reference
- */
-export function pinCollection(url: string, hash: Reference): Promise<BeeResponse> {
-  return pin(url, Endpoint.COLLECTION, hash)
-}
-
-/**
- * Unpin collection with given reference
- *
- * @param url  Bee URL
- * @param hash Bee collection reference
- */
-export function unpinCollection(url: string, hash: Reference): Promise<BeeResponse> {
-  return unpin(url, Endpoint.COLLECTION, hash)
+export interface GetAllPinResponse {
+  chunks: Pin[]
 }
 
 /**
  * Pin data with given reference
  *
  * @param url  Bee URL
- * @param hash Bee data reference
+ * @param reference Bee data reference
  */
-export function pinData(url: string, hash: Reference): Promise<BeeResponse> {
-  return pin(url, Endpoint.BYTES, hash)
+export async function pin(url: string, reference: Reference): Promise<BeeResponse> {
+  const response = await safeAxios<BeeResponse>({
+    method: 'post',
+    responseType: 'json',
+    url: `${url}${PINNING_ENDPOINT}/${reference}`,
+  })
+
+  return response.data
 }
 
 /**
  * Unpin data with given reference
  *
  * @param url  Bee URL
- * @param hash Bee data reference
+ * @param reference Bee data reference
  */
-export function unpinData(url: string, hash: Reference): Promise<BeeResponse> {
-  return unpin(url, Endpoint.BYTES, hash)
-}
-
-/**
- * Pin chunks with given reference
- *
- * @param url  Bee URL
- * @param hash Bee data reference
- */
-export function pinChunk(url: string, hash: Reference): Promise<BeeResponse> {
-  return pin(url, Endpoint.CHUNKS, hash)
-}
-
-/**
- * Unpin chunks with given reference
- *
- * @param url  Bee URL
- * @param hash Bee data reference
- */
-export function unpinChunk(url: string, hash: Reference): Promise<BeeResponse> {
-  return unpin(url, Endpoint.CHUNKS, hash)
-}
-
-/**
- * Get pinning status of chunk with given reference
- *
- * @param url  Bee URL
- * @param hash Bee data reference
- */
-export async function getChunkPinningStatus(url: string, hash: Reference): Promise<PinningStatus> {
-  const response = await safeAxios<PinningStatus>({
-    method: 'get',
+export async function unpin(url: string, reference: Reference): Promise<BeeResponse> {
+  const response = await safeAxios<BeeResponse>({
+    method: 'delete',
     responseType: 'json',
-    url: `${url}${Endpoint.CHUNKS}/${hash}`,
+    url: `${url}${PINNING_ENDPOINT}/${reference}`,
   })
 
   return response.data
 }
 
 /**
- * Update pin counter of chunk with given reference
- *
- * @param url         Bee URL
- * @param hash        Bee data reference
- * @param pinCounter  New value of the pin counter
- */
-export async function updateChunkPinCounter(url: string, hash: Reference, pinCounter: number): Promise<PinningStatus> {
-  const response = await safeAxios<PinningStatus>({
-    method: 'put',
-    responseType: 'json',
-    url: `${url}${Endpoint.CHUNKS}/${hash}`,
-    data: {
-      pinCounter,
-    },
-  })
-
-  return response.data
-}
-
-/**
- * Optional parameters to change listing
- */
-export interface PinnedChunksOptions {
-  /**
-   * Offset of the items returned.
-   * Maximum value is 2147483647
-   */
-  offset?: number
-  /**
-   * Limits the number of item returned. By default Bee returns 100 items.
-   * Maximum value is 2147483647
-   */
-  limit?: number
-}
-
-/**
- * Get list of pinned chunks
+ * Get pin status for specific address.
  *
  * @param url     Bee URL
- * @param options Optional offset and limit of listing
+ * @param reference
+ * @throws Error if given address is not pinned
  */
-export async function getPinnedChunks(url: string, options?: PinnedChunksOptions): Promise<PinnedChunks> {
-  const response = await safeAxios<PinnedChunks>({
+export async function getPin(url: string, reference: Reference): Promise<Pin> {
+  const response = await safeAxios<Pin>({
     method: 'get',
     responseType: 'json',
-    url: `${url}${Endpoint.CHUNKS}`,
-    params: options,
+    url: `${url}${PINNING_ENDPOINT}/${reference}`,
   })
 
   return response.data
+}
+
+/**
+ * Get list of all pins
+ *
+ * @param url     Bee URL
+ */
+export async function getAllPins(url: string): Promise<Pin[]> {
+  const response = await safeAxios<GetAllPinResponse>({
+    method: 'get',
+    responseType: 'json',
+    url: `${url}${PINNING_ENDPOINT}`,
+  })
+
+  return response.data.chunks
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -80,6 +80,10 @@ export interface FileData<T> extends FileHeaders {
   data: T
 }
 
+export interface Pin {
+  address: string
+}
+
 /**
  * Helper interface that adds utility functions
  * to work more conveniently with bytes in normal

--- a/test/integration/bee-class.browser.spec.ts
+++ b/test/integration/bee-class.browser.spec.ts
@@ -70,7 +70,7 @@ describe('Bee class - in browser', () => {
       async (BEE_URL, fileHash) => {
         const bee = new window.BeeJs.Bee(BEE_URL)
 
-        return await bee.pinFile(fileHash)
+        return await bee.pin(fileHash)
       },
       BEE_URL,
       fileHash,
@@ -81,7 +81,7 @@ describe('Bee class - in browser', () => {
       async (BEE_URL, fileHash) => {
         const bee = new window.BeeJs.Bee(BEE_URL)
 
-        return await bee.unpinFile(fileHash)
+        return await bee.unpin(fileHash)
       },
       BEE_URL,
       fileHash,

--- a/test/integration/bee-class.spec.ts
+++ b/test/integration/bee-class.spec.ts
@@ -115,17 +115,17 @@ describe('Bee class', () => {
   })
 
   describe('pinning', () => {
-    it('should list pinned chunks', async () => {
+    it('should list all pins', async () => {
       const content = new Uint8Array([1, 2, 3])
       const hash = await bee.uploadFile(content)
 
-      const pinResponse = await bee.pinFile(hash)
+      const pinResponse = await bee.pin(hash)
       expect(pinResponse).toEqual(okResponse)
 
-      const pinnedChunks = await bee.getPinnedChunks()
-      expect(pinnedChunks).toHaveProperty('chunks')
-      expect(pinnedChunks.chunks.length).toBeGreaterThanOrEqual(1)
-      expect(pinnedChunks.chunks.find(chunk => chunk.address === hash)).toBeTruthy()
+      const pinnedChunks = await bee.getAllPins()
+      expect(pinnedChunks).toBe('array')
+      expect(pinnedChunks.length).toEqual(1)
+      expect(pinnedChunks.find(chunk => chunk.address === hash)).toBeTruthy()
     })
 
     it('should get pinning status', async () => {
@@ -134,15 +134,14 @@ describe('Bee class', () => {
         pin: false,
       })
 
-      const statusBeforePinning = bee.getChunkPinningStatus(hash)
+      const statusBeforePinning = bee.getPin(hash)
       await expect(statusBeforePinning).rejects.toThrowError('Not Found')
 
-      const pinResponse = await bee.pinFile(hash)
+      const pinResponse = await bee.pin(hash)
       expect(pinResponse).toEqual(okResponse)
 
-      const statusAfterPinning = await bee.getChunkPinningStatus(hash)
+      const statusAfterPinning = await bee.getPin(hash)
       expect(statusAfterPinning).toHaveProperty('address', hash)
-      expect(statusAfterPinning).toHaveProperty('pinCounter', 1)
     })
 
     it('should pin and unpin files', async () => {
@@ -150,22 +149,10 @@ describe('Bee class', () => {
 
       const hash = await bee.uploadFile(content)
 
-      const pinResponse = await bee.pinFile(hash)
+      const pinResponse = await bee.pin(hash)
       expect(pinResponse).toEqual(okResponse)
 
-      const unpinResponse = await bee.unpinFile(hash)
-      expect(unpinResponse).toEqual(okResponse)
-    })
-
-    it('should pin and unpin chunks', async () => {
-      const content = new Uint8Array([1, 2, 3])
-
-      const hash = await bee.uploadFile(content)
-
-      const pinResponse = await bee.pinChunk(hash)
-      expect(pinResponse).toEqual(okResponse)
-
-      const unpinResponse = await bee.unpinChunk(hash)
+      const unpinResponse = await bee.unpin(hash)
       expect(unpinResponse).toEqual(okResponse)
     })
 
@@ -173,10 +160,10 @@ describe('Bee class', () => {
       const path = './test/data/'
       const hash = await bee.uploadFilesFromDirectory(path)
 
-      const pinResponse = await bee.pinCollection(hash)
+      const pinResponse = await bee.pin(hash)
       expect(pinResponse).toEqual(okResponse)
 
-      const unpinResponse = await bee.unpinCollection(hash)
+      const unpinResponse = await bee.unpin(hash)
       expect(unpinResponse).toEqual(okResponse)
     })
 
@@ -185,10 +172,10 @@ describe('Bee class', () => {
 
       const hash = await bee.uploadData(content)
 
-      const pinResponse = await bee.pinData(hash)
+      const pinResponse = await bee.pin(hash)
       expect(pinResponse).toEqual(okResponse)
 
-      const unpinResponse = await bee.unpinData(hash)
+      const unpinResponse = await bee.unpin(hash)
       expect(unpinResponse).toEqual(okResponse)
     })
   })

--- a/test/integration/modules/pinning.spec.ts
+++ b/test/integration/modules/pinning.spec.ts
@@ -21,14 +21,14 @@ describe('modules/pin', () => {
 
     it('should pin an existing file', async () => {
       const hash = await bzz.uploadFile(BEE_URL, randomData)
-      const response = await pinning.pinFile(BEE_URL, hash)
+      const response = await pinning.pin(BEE_URL, hash)
 
       expect(response).toEqual(okResponse)
     })
 
     it('should unpin an existing file', async () => {
       const hash = await bzz.uploadFile(BEE_URL, randomData)
-      const response = await pinning.unpinFile(BEE_URL, hash)
+      const response = await pinning.unpin(BEE_URL, hash)
 
       expect(response).toEqual(okResponse)
     })
@@ -36,13 +36,13 @@ describe('modules/pin', () => {
     it(
       'should not pin a non-existing file',
       async () => {
-        await expect(pinning.pinFile(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+        await expect(pinning.pin(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
       },
       ERR_TIMEOUT,
     )
 
     it('should not unpin a non-existing file', async () => {
-      await expect(pinning.unpinFile(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+      await expect(pinning.unpin(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
     })
   })
 
@@ -60,14 +60,14 @@ describe('modules/pin', () => {
 
     it('should pin an existing collection', async () => {
       const hash = await bzz.uploadCollection(BEE_URL, testCollection)
-      const response = await pinning.pinCollection(BEE_URL, hash)
+      const response = await pinning.pin(BEE_URL, hash)
 
       expect(response).toEqual(okResponse)
     })
 
     it('should unpin an existing collections', async () => {
       const hash = await bzz.uploadCollection(BEE_URL, testCollection)
-      const response = await pinning.unpinCollection(BEE_URL, hash)
+      const response = await pinning.unpin(BEE_URL, hash)
 
       expect(response).toEqual(okResponse)
     })
@@ -75,13 +75,13 @@ describe('modules/pin', () => {
     it(
       'should not pin a non-existing collections',
       async () => {
-        await expect(pinning.pinCollection(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+        await expect(pinning.pin(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
       },
       ERR_TIMEOUT,
     )
 
     it('should not unpin a non-existing collections', async () => {
-      await expect(pinning.unpinCollection(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+      await expect(pinning.unpin(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
     })
   })
 
@@ -90,14 +90,14 @@ describe('modules/pin', () => {
 
     it('should pin existing data', async () => {
       const hash = await bytes.upload(BEE_URL, randomData)
-      const response = await pinning.pinData(BEE_URL, hash)
+      const response = await pinning.pin(BEE_URL, hash)
 
       expect(response).toEqual(okResponse)
     })
 
     it('should unpin existing data', async () => {
       const hash = await bytes.upload(BEE_URL, randomData)
-      const response = await pinning.unpinData(BEE_URL, hash)
+      const response = await pinning.pin(BEE_URL, hash)
 
       expect(response).toEqual(okResponse)
     })
@@ -105,13 +105,13 @@ describe('modules/pin', () => {
     it(
       'should not pin a non-existing data',
       async () => {
-        await expect(pinning.pinData(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+        await expect(pinning.pin(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
       },
       ERR_TIMEOUT,
     )
 
     it('should not unpin a non-existing data', async () => {
-      await expect(pinning.unpinData(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+      await expect(pinning.pin(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
     })
   })
 
@@ -120,7 +120,7 @@ describe('modules/pin', () => {
       const chunkResponse = await chunk.upload(BEE_URL, testChunkData)
       expect(chunkResponse).toEqual({ reference: testChunkHash })
 
-      const pinningResponse = await pinning.pinChunk(BEE_URL, testChunkHash)
+      const pinningResponse = await pinning.pin(BEE_URL, testChunkHash)
       expect(pinningResponse).toEqual(okResponse)
     })
 
@@ -128,61 +128,43 @@ describe('modules/pin', () => {
       const chunkResponse = await chunk.upload(BEE_URL, testChunkData)
       expect(chunkResponse).toEqual({ reference: testChunkHash })
 
-      const pinningResponse = await pinning.unpinChunk(BEE_URL, testChunkHash)
+      const pinningResponse = await pinning.unpin(BEE_URL, testChunkHash)
       expect(pinningResponse).toEqual(okResponse)
     })
 
     it(
       'should not pin a non-existing chunk',
       async () => {
-        await expect(pinning.pinChunk(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+        await expect(pinning.pin(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
       },
       ERR_TIMEOUT,
     )
 
     it('should not unpin a non-existing chunk', async () => {
-      await expect(pinning.unpinChunk(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
+      await expect(pinning.unpin(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
     })
 
     it('should return pinning status of existing chunk', async () => {
       const chunkResponse = await chunk.upload(BEE_URL, testChunkData)
       expect(chunkResponse).toEqual({ reference: testChunkHash })
 
-      const pinningResponse = await pinning.pinChunk(BEE_URL, testChunkHash)
+      const pinningResponse = await pinning.pin(BEE_URL, testChunkHash)
       expect(pinningResponse).toEqual(okResponse)
 
-      const pinningStatus = await pinning.getChunkPinningStatus(BEE_URL, testChunkHash)
+      const pinningStatus = await pinning.getPin(BEE_URL, testChunkHash)
       expect(pinningStatus.address).toEqual(testChunkHash)
-      expect(pinningStatus.pinCounter).toBeGreaterThan(0)
     })
 
     it('should not return pinning status of non-existing chunk', async () => {
-      await expect(pinning.getChunkPinningStatus(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
-    })
-
-    it('should return pinning status of existing chunk', async () => {
-      const chunkResponse = await chunk.upload(BEE_URL, testChunkData)
-      expect(chunkResponse).toEqual({ reference: testChunkHash })
-
-      const pinningResponse = await pinning.pinChunk(BEE_URL, testChunkHash)
-      expect(pinningResponse).toEqual(okResponse)
-
-      const pinCounter = 100
-      const pinningStatus = await pinning.updateChunkPinCounter(BEE_URL, testChunkHash, pinCounter)
-      expect(pinningStatus.address).toEqual(testChunkHash)
-      expect(pinningStatus.pinCounter).toBe(pinCounter)
+      await expect(pinning.getPin(BEE_URL, invalidReference)).rejects.toThrow('Not Found')
     })
 
     it('should return list of pinned chunks', async () => {
       const chunkResponse = await chunk.upload(BEE_URL, testChunkData)
       expect(chunkResponse).toEqual({ reference: testChunkHash })
 
-      const pinningResponse = await pinning.pinChunk(BEE_URL, testChunkHash)
+      const pinningResponse = await pinning.pin(BEE_URL, testChunkHash)
       expect(pinningResponse).toEqual(okResponse)
-
-      const pinnedChunks = await pinning.getPinnedChunks(BEE_URL, { limit: 2_147_483_647 })
-      expect(pinnedChunks.chunks.length).toBeGreaterThan(0)
-      expect(pinnedChunks.chunks.map(status => status.address)).toContain(testChunkHash)
     })
   })
 })


### PR DESCRIPTION
Closes #292 

Breaking changes:

 - Following methods are removed `bee.pinFile()`, `bee.unpinFile()`, `bee.pinCollection()` `bee.unpinCollection()`, `bee.pinData()`, `bee.unpinData()`, `bee.pinChunk()`, `bee.unpinChunk()`, `bee. getChunkPinningStatus()`