### PR TITLE
docs: changed mattermost link to discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ There are some ways you can make this module better:
 
 - Consult our [open issues](https://github.com/ethersphere/bee-js/issues) and take on one of them
 - Help our tests reach 100% coverage!
-- Join us in our [Mattermost chat](https://beehive.ethswarm.org/swarm/channels/swarm-javascript) if you have questions or want to give feedback
+- Join us in our [Discord chat](https://discord.com/channels/799027393297514537/811574542069137449) if you have questions or want to give feedback
 
 ### Setup
 


### PR DESCRIPTION
Not sure which link to use for Discord. The provided link points to the #develop-on-swarm channel, but I don't know how it works if someone is not on the Discord server already.