### PR TITLE
refactor!: camelCasing of some properties

### DIFF
--- a/src/types/debug.ts
+++ b/src/types/debug.ts
@@ -5,8 +5,8 @@ export interface Settlements {
 }
 
 export interface AllSettlements {
-  totalreceived: bigint
-  totalsent: bigint
+  totalReceived: bigint
+  totalSent: bigint
   settlements: Settlements[]
 }
 
@@ -14,8 +14,8 @@ export interface NodeAddresses {
   overlay: string
   underlay: string[]
   ethereum: string
-  public_key: string
-  pss_public_key: string
+  publicKey: string
+  pssPublicKey: string
 }
 
 export interface Peer {
@@ -23,8 +23,7 @@ export interface Peer {
 }
 
 export interface ChequebookAddressResponse {
-  // see this issue regarding the naming https://github.com/ethersphere/bee/issues/1078
-  chequebookaddress: string
+  chequebookAddress: string
 }
 
 export interface ChequebookBalanceResponse {
@@ -59,8 +58,8 @@ export interface Cheque {
 
 export interface LastChequesForPeerResponse {
   peer: string
-  lastreceived: Cheque
-  lastsent: Cheque
+  lastReceived: Cheque
+  lastSent: Cheque
 }
 
 export interface LastChequesResponse {

--- a/test/integration/bee-class.browser.spec.ts
+++ b/test/integration/bee-class.browser.spec.ts
@@ -164,11 +164,11 @@ describe('Bee class - in browser', () => {
             const bee = new window.BeeJs.Bee(BEE_URL)
             const beeDebug = new window.BeeJs.BeeDebug(BEE_DEBUG_URL)
 
-            const { overlay, pss_public_key } = await beeDebug.getNodeAddresses()
+            const { overlay, pssPublicKey } = await beeDebug.getNodeAddresses()
             const beePeer = new window.BeeJs.Bee(BEE_PEER_URL)
 
             const receive = bee.pssReceive(topic)
-            await beePeer.pssSend(topic, overlay, message, pss_public_key)
+            await beePeer.pssSend(topic, overlay, message, pssPublicKey)
 
             const msg = await receive
 

--- a/test/integration/bee-class.spec.ts
+++ b/test/integration/bee-class.spec.ts
@@ -212,9 +212,9 @@ describe('Bee class', () => {
           done()
         })
 
-        const { overlay, pss_public_key } = await beeDebug.getNodeAddresses()
+        const { overlay, pssPublicKey } = await beeDebug.getNodeAddresses()
         const beePeer = new Bee(beePeerUrl())
-        await beePeer.pssSend(topic, overlay, message, pss_public_key)
+        await beePeer.pssSend(topic, overlay, message, pssPublicKey)
       },
       PSS_TIMEOUT,
     )

--- a/test/integration/modules/debug/chequebook.spec.ts
+++ b/test/integration/modules/debug/chequebook.spec.ts
@@ -13,7 +13,7 @@ if (process.env.BEE_TEST_CHEQUEBOOK) {
     test('address', async () => {
       const response = await getChequebookAddress(beeDebugUrl())
 
-      expect(isPrefixedHexString(response.chequebookaddress)).toBeTruthy()
+      expect(isPrefixedHexString(response.chequebookAddress)).toBeTruthy()
     })
 
     test('balance', async () => {

--- a/test/integration/modules/debug/connectivity.spec.ts
+++ b/test/integration/modules/debug/connectivity.spec.ts
@@ -56,7 +56,7 @@ describe('modules/debug/connectivity', () => {
     expect(addresses.overlay).toMatch(/^[0-9a-f]{64}$/)
     expect(Array.isArray(addresses.underlay)).toBeTruthy()
     expect(addresses.ethereum).toMatch(/^0x[0-9a-f]{40}$/)
-    expect(addresses.public_key).toMatch(/^[0-9a-f]{66}$/)
+    expect(addresses.publicKey).toMatch(/^[0-9a-f]{66}$/)
     expect(addresses.pssPublicKey).toMatch(/^[0-9a-f]{66}$/)
   })
 

--- a/test/integration/modules/debug/connectivity.spec.ts
+++ b/test/integration/modules/debug/connectivity.spec.ts
@@ -57,7 +57,7 @@ describe('modules/debug/connectivity', () => {
     expect(Array.isArray(addresses.underlay)).toBeTruthy()
     expect(addresses.ethereum).toMatch(/^0x[0-9a-f]{40}$/)
     expect(addresses.public_key).toMatch(/^[0-9a-f]{66}$/)
-    expect(addresses.pss_public_key).toMatch(/^[0-9a-f]{66}$/)
+    expect(addresses.pssPublicKey).toMatch(/^[0-9a-f]{66}$/)
   })
 
   test('pingPeer', async () => {

--- a/test/integration/modules/debug/settlements.spec.ts
+++ b/test/integration/modules/debug/settlements.spec.ts
@@ -5,8 +5,8 @@ describe('settlements', () => {
   test('all settlements', async () => {
     const response = await settlements.getAllSettlements(beeDebugUrl())
 
-    expect(typeof response.totalreceived).toBe('bigint')
-    expect(typeof response.totalsent).toBe('bigint')
+    expect(typeof response.totalReceived).toBe('bigint')
+    expect(typeof response.totalSent).toBe('bigint')
     expect(Array.isArray(response.settlements)).toBeTruthy()
 
     if (response.settlements.length > 0) {

--- a/test/integration/modules/pss.spec.ts
+++ b/test/integration/modules/pss.spec.ts
@@ -76,7 +76,7 @@ describe('modules/pss', () => {
 
       const addresses = await connectivity.getNodeAddresses(debugUrl)
       const target = addresses.overlay
-      const recipient = addresses.pss_public_key
+      const recipient = addresses.pssPublicKey
       await pss.send(BEE_PEER_URL, topic, target, message, recipient)
     },
     PSS_TIMEOUT,


### PR DESCRIPTION
Closes #294.

Breaking changes:
 - Following properties were converted from snake_case to camelCase:
	 - `BeeDebug.getNodeAddresses()`: `public_key`, `pss_public_key`
	 - `BeeDebug.getChequebookAddress()`: `chequebookaddress`
	 - `BeeDebug.getAllSettlements()`: `total_received`, `total_sent`