### PR TITLE
docs: changed mattermost link to discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ There are some ways you can make this module better:
 
 - Consult our [open issues](https://github.com/ethersphere/bee-js/issues) and take on one of them
 - Help our tests reach 100% coverage!
-- Join us in our [Mattermost chat](https://beehive.ethswarm.org/swarm/channels/swarm-javascript) if you have questions or want to give feedback
+- Join us in our [Discord chat](https://discord.gg/wdghaQsGq5) in the #develop-on-swarm channel if you have questions or want to give feedback
 
 ### Setup
 


### PR DESCRIPTION
This PR uses an invite link for Discord, so that people can join