### PR TITLE
feat: limit postage depth

### DIFF
--- a/src/bee.ts
+++ b/src/bee.ts
@@ -50,7 +50,6 @@ import { assertAddress, assertNonNegativeInteger, assertReference } from './util
 import { setJsonData, getJsonData } from './feed/json'
 import { makeCollectionFromFS, makeCollectionFromFileList } from './utils/collection'
 import { PostageBatchOptions } from './types'
-import { MINIMUM_DEPTH } from './modules/stamps'
 
 /**
  * The Bee class provides a way of interacting with the Bee APIs based on the provided url
@@ -578,7 +577,11 @@ export class Bee {
     assertNonNegativeInteger(depth)
 
     if (depth < stamps.MINIMUM_DEPTH) {
-      throw new BeeArgumentError('Depth has to be greater or equal then 16', depth)
+      throw new BeeArgumentError(`Depth has to be at least ${stamps.MINIMUM_DEPTH}`, depth)
+    }
+
+    if (depth > stamps.MAXIMUM_DEPTH) {
+      throw new BeeArgumentError(`Depth has to be at most ${stamps.MAXIMUM_DEPTH}`, depth)
     }
 
     if (options?.gasPrice) {

--- a/src/bee.ts
+++ b/src/bee.ts
@@ -33,7 +33,7 @@ import type {
   Address,
   PostageBatch,
 } from './types'
-import { BeeError } from './utils/error'
+import { BeeArgumentError, BeeError } from './utils/error'
 import { prepareWebsocketData } from './utils/data'
 import { fileArrayBuffer, isFile } from './utils/file'
 import { AxiosRequestConfig } from 'axios'
@@ -50,6 +50,7 @@ import { assertAddress, assertNonNegativeInteger, assertReference } from './util
 import { setJsonData, getJsonData } from './feed/json'
 import { makeCollectionFromFS, makeCollectionFromFileList } from './utils/collection'
 import { PostageBatchOptions } from './types'
+import { MINIMUM_DEPTH } from './modules/stamps'
 
 /**
  * The Bee class provides a way of interacting with the Bee APIs based on the provided url
@@ -575,6 +576,10 @@ export class Bee {
   async createPostageBatch(amount: bigint, depth: number, options?: PostageBatchOptions): Promise<Address> {
     assertNonNegativeInteger(amount)
     assertNonNegativeInteger(depth)
+
+    if (depth < stamps.MINIMUM_DEPTH) {
+      throw new BeeArgumentError('Depth has to be greater or equal then 16', depth)
+    }
 
     if (options?.gasPrice) {
       assertNonNegativeInteger(options.gasPrice)

--- a/src/modules/stamps.ts
+++ b/src/modules/stamps.ts
@@ -2,6 +2,7 @@ import { Address, PostageBatch, PostageBatchOptions } from '../types'
 import { safeAxios } from '../utils/safeAxios'
 
 const STAMPS_ENDPOINT = '/stamps'
+export const MINIMUM_DEPTH = 16
 
 interface GetAllStampsResponse {
   stamps: PostageBatch[]

--- a/src/modules/stamps.ts
+++ b/src/modules/stamps.ts
@@ -3,6 +3,7 @@ import { safeAxios } from '../utils/safeAxios'
 
 const STAMPS_ENDPOINT = '/stamps'
 export const MINIMUM_DEPTH = 16
+export const MAXIMUM_DEPTH = 255
 
 interface GetAllStampsResponse {
   stamps: PostageBatch[]

--- a/test/unit/bee-class.spec.ts
+++ b/test/unit/bee-class.spec.ts
@@ -158,5 +158,12 @@ describe('Bee class', () => {
         BeeArgumentError,
       )
     })
+
+    it('should throw error if too small depth', async () => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      await expect(bee.createPostageBatch(BigInt('10'), -1)).rejects.toThrow(BeeArgumentError)
+      await expect(bee.createPostageBatch(BigInt('10'), 15)).rejects.toThrow(BeeArgumentError)
+    })
   })
 })

--- a/test/unit/bee-class.spec.ts
+++ b/test/unit/bee-class.spec.ts
@@ -165,5 +165,11 @@ describe('Bee class', () => {
       await expect(bee.createPostageBatch(BigInt('10'), -1)).rejects.toThrow(BeeArgumentError)
       await expect(bee.createPostageBatch(BigInt('10'), 15)).rejects.toThrow(BeeArgumentError)
     })
+
+    it('should throw error if too big depth', async () => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      await expect(bee.createPostageBatch(BigInt('10'), 256)).rejects.toThrow(BeeArgumentError)
+    })
   })
 })


### PR DESCRIPTION
When implementing the Postage batch support I forgot that depth is limited to at least 16. This adds a check for this.