### PR TITLE
feat!: support gas price and limit for cashout

### DIFF
--- a/src/bee-debug.ts
+++ b/src/bee-debug.ts
@@ -25,7 +25,9 @@ import type {
   NodeAddresses,
 } from './types'
 import { assertBeeUrl, stripLastSlash } from './utils/url'
-import { assertAddress, assertInteger } from './utils/type'
+import { assertAddress, assertInteger, assertNonNegativeInteger } from './utils/type'
+import { CashoutOptions } from './types'
+import { add } from 'husky'
 
 /**
  * The BeeDebug class provides a way of interacting with the Bee debug APIs based on the provided url
@@ -165,9 +167,23 @@ export class BeeDebug {
    * Cashout the last cheque for the peer
    *
    * @param address  Swarm address of peer
+   * @param options
+   * @param options.gasPrice Gas price for the cashout transaction in WEI
+   * @param options.gasLimit Gas limit for the cashout transaction in WEI
    */
-  cashoutLastCheque(address: string): Promise<CashoutResponse> {
-    return chequebook.cashoutLastCheque(this.url, address)
+  // eslint-disable-next-line require-await
+  async cashoutLastCheque(address: string | Address, options?: CashoutOptions): Promise<CashoutResponse> {
+    assertAddress(address)
+
+    if (options?.gasLimit) {
+      assertNonNegativeInteger(options.gasLimit)
+    }
+
+    if (options?.gasPrice) {
+      assertNonNegativeInteger(options.gasPrice)
+    }
+
+    return chequebook.cashoutLastCheque(this.url, address, options)
   }
 
   /**

--- a/src/bee-debug.ts
+++ b/src/bee-debug.ts
@@ -27,7 +27,6 @@ import type {
 import { assertBeeUrl, stripLastSlash } from './utils/url'
 import { assertAddress, assertInteger, assertNonNegativeInteger } from './utils/type'
 import { CashoutOptions } from './types'
-import { add } from 'husky'
 
 /**
  * The BeeDebug class provides a way of interacting with the Bee debug APIs based on the provided url

--- a/src/bee-debug.ts
+++ b/src/bee-debug.ts
@@ -171,7 +171,7 @@ export class BeeDebug {
    * @param options.gasLimit Gas limit for the cashout transaction in WEI
    */
   // eslint-disable-next-line require-await
-  async cashoutLastCheque(address: string | Address, options?: CashoutOptions): Promise<CashoutResponse> {
+  async cashoutLastCheque(address: string | Address, options?: CashoutOptions): Promise<string> {
     assertAddress(address)
 
     if (options?.gasLimit) {

--- a/src/modules/debug/chequebook.ts
+++ b/src/modules/debug/chequebook.ts
@@ -65,7 +65,7 @@ export async function getLastCashoutAction(url: string, peer: string): Promise<L
  * @param peer  Swarm address of peer
  * @param options
  */
-export async function cashoutLastCheque(url: string, peer: string, options?: CashoutOptions): Promise<CashoutResponse> {
+export async function cashoutLastCheque(url: string, peer: string, options?: CashoutOptions): Promise<string> {
   const headers: Record<string, string> = {}
 
   if (options?.gasPrice) {
@@ -83,7 +83,7 @@ export async function cashoutLastCheque(url: string, peer: string, options?: Cas
     headers,
   })
 
-  return response.data
+  return response.data.transactionHash
 }
 
 /**

--- a/src/modules/debug/chequebook.ts
+++ b/src/modules/debug/chequebook.ts
@@ -9,6 +9,7 @@ import type {
   DepositTokensResponse,
   WithdrawTokensResponse,
 } from '../../types'
+import { CashoutOptions } from '../../types'
 
 const chequebookEndpoint = '/chequebook'
 
@@ -62,12 +63,24 @@ export async function getLastCashoutAction(url: string, peer: string): Promise<L
  *
  * @param url   Bee debug url
  * @param peer  Swarm address of peer
+ * @param options
  */
-export async function cashoutLastCheque(url: string, peer: string): Promise<CashoutResponse> {
+export async function cashoutLastCheque(url: string, peer: string, options?: CashoutOptions): Promise<CashoutResponse> {
+  const headers: Record<string, string> = {}
+
+  if (options?.gasPrice) {
+    headers['gas-price'] = options.gasPrice.toString()
+  }
+
+  if (options?.gasLimit) {
+    headers['gas-limit'] = options.gasLimit.toString()
+  }
+
   const response = await safeAxios<CashoutResponse>({
     method: 'post',
     url: url + chequebookEndpoint + `/cashout/${peer}`,
     responseType: 'json',
+    headers,
   })
 
   return response.data

--- a/src/types/debug.ts
+++ b/src/types/debug.ts
@@ -31,6 +31,18 @@ export interface ChequebookBalanceResponse {
   availableBalance: bigint
 }
 
+export interface CashoutOptions {
+  /**
+   * Gas price for the cashout transaction in WEI
+   */
+  gasPrice?: bigint
+
+  /**
+   * Gas limit for the cashout transaction in WEI
+   */
+  gasLimit?: bigint
+}
+
 export interface CashoutResult {
   recipient: string
   lastPayout: bigint

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -238,7 +238,7 @@ export interface PostageBatch {
  */
 export interface PostageBatchOptions {
   label?: string
-  gasPrice?: bigint | number
+  gasPrice?: bigint
 }
 
 /*********************************************************

--- a/test/unit/bee-class.spec.ts
+++ b/test/unit/bee-class.spec.ts
@@ -1,5 +1,5 @@
 import { assertAllIsDone, createPostageBatchMock, downloadDataMock, fetchFeedUpdateMock, MOCK_SERVER_URL } from './nock'
-import { Bee, BeeArgumentError, BeeError, ReferenceResponse } from '../../src'
+import { Bee, BeeArgumentError, ReferenceResponse } from '../../src'
 import { testIdentity, testJsonHash, testJsonPayload, testJsonStringPayload } from '../utils'
 import { makeTopicFromString } from '../../src/feed/topic'
 
@@ -153,7 +153,6 @@ describe('Bee class', () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore: Input testing
       await expect(bee.createPostageBatch(BigInt('10'), 17, { gasPrice: true })).rejects.toThrow(TypeError)
-      await expect(bee.createPostageBatch(BigInt('10'), 17, { gasPrice: -1 })).rejects.toThrow(BeeArgumentError)
       await expect(bee.createPostageBatch(BigInt('10'), 17, { gasPrice: BigInt('-1') })).rejects.toThrow(
         BeeArgumentError,
       )

--- a/test/unit/bee-debug-class.spec.ts
+++ b/test/unit/bee-debug-class.spec.ts
@@ -1,0 +1,114 @@
+import { assertAllIsDone, cashoutLastChequeMock, MOCK_SERVER_URL } from './nock'
+import { BeeArgumentError, BeeDebug } from '../../src'
+import { testAddress } from '../utils'
+
+describe('BeeDebug class', () => {
+  function testUrl(url: unknown): void {
+    it(`should not accept invalid url '${url}'`, () => {
+      try {
+        new BeeDebug(url as string)
+        fail('BeeDebug constructor should have thrown error.')
+      } catch (e) {
+        if (e instanceof BeeArgumentError) {
+          expect(e.value).toEqual(url)
+
+          return
+        }
+
+        throw e
+      }
+    })
+  }
+
+  testUrl('')
+  testUrl(null)
+  testUrl(undefined)
+  testUrl(1)
+  testUrl('some-invalid-url')
+  testUrl('invalid:protocol')
+  // eslint-disable-next-line no-script-url
+  testUrl('javascript:console.log()')
+  testUrl('ws://localhost:1633')
+
+  describe('cashoutLastCheque', () => {
+    const TRANSACTION_HASH = '36b7efd913ca4cf880b8eeac5093fa27b0825906c600685b6abdd6566e6cfe8f'
+    const CASHOUT_RESPONSE = {
+      transactionHash: TRANSACTION_HASH,
+    }
+
+    it('should not pass headers if no gas price is specified', async () => {
+      cashoutLastChequeMock(testAddress).reply(201, CASHOUT_RESPONSE)
+
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+      await expect(bee.cashoutLastCheque(testAddress)).resolves.toEqual(CASHOUT_RESPONSE)
+      assertAllIsDone()
+    })
+
+    it('should pass headers if gas price is specified', async () => {
+      cashoutLastChequeMock(testAddress, '100000000000').reply(201, CASHOUT_RESPONSE)
+
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+      await expect(bee.cashoutLastCheque(testAddress, { gasPrice: BigInt('100000000000') })).resolves.toEqual(
+        CASHOUT_RESPONSE,
+      )
+      assertAllIsDone()
+    })
+
+    it('should pass headers if gas limit is specified', async () => {
+      cashoutLastChequeMock(testAddress, undefined, '100000000000').reply(201, CASHOUT_RESPONSE)
+
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+      await expect(bee.cashoutLastCheque(testAddress, { gasLimit: BigInt('100000000000') })).resolves.toEqual(
+        CASHOUT_RESPONSE,
+      )
+      assertAllIsDone()
+    })
+
+    it('should throw error if passed wrong address', async () => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore: Input testing
+      await expect(bee.cashoutLastCheque(true)).rejects.toThrow(TypeError)
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore: Input testing
+      await expect(bee.cashoutLastCheque(11)).rejects.toThrow(TypeError)
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore: Input testing
+      await expect(bee.cashoutLastCheque(null)).rejects.toThrow(TypeError)
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore: Input testing
+      await expect(bee.cashoutLastCheque()).rejects.toThrow(TypeError)
+
+      await expect(bee.cashoutLastCheque('')).rejects.toThrow(TypeError)
+      await expect(bee.cashoutLastCheque('asd')).rejects.toThrow(TypeError)
+    })
+
+    it('should throw error if passed wrong gas price input', async () => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore: Input testing
+      await expect(bee.cashoutLastCheque(testAddress, { gasPrice: 'asd' })).rejects.toThrow(TypeError)
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore: Input testing
+      await expect(bee.cashoutLastCheque(testAddress, { gasPrice: true })).rejects.toThrow(TypeError)
+      await expect(bee.cashoutLastCheque(testAddress, { gasPrice: BigInt('-1') })).rejects.toThrow(BeeArgumentError)
+    })
+
+    it('should throw error if passed wrong gas limit input', async () => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore: Input testing
+      await expect(bee.cashoutLastCheque(testAddress, { gasLimit: 'asd' })).rejects.toThrow(TypeError)
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore: Input testing
+      await expect(bee.cashoutLastCheque(testAddress, { gasLimit: true })).rejects.toThrow(TypeError)
+      await expect(bee.cashoutLastCheque(testAddress, { gasLimit: BigInt('-1') })).rejects.toThrow(BeeArgumentError)
+    })
+  })
+})

--- a/test/unit/bee-debug-class.spec.ts
+++ b/test/unit/bee-debug-class.spec.ts
@@ -40,7 +40,7 @@ describe('BeeDebug class', () => {
       cashoutLastChequeMock(testAddress).reply(201, CASHOUT_RESPONSE)
 
       const bee = new BeeDebug(MOCK_SERVER_URL)
-      await expect(bee.cashoutLastCheque(testAddress)).resolves.toEqual(CASHOUT_RESPONSE)
+      await expect(bee.cashoutLastCheque(testAddress)).resolves.toEqual(TRANSACTION_HASH)
       assertAllIsDone()
     })
 
@@ -49,7 +49,7 @@ describe('BeeDebug class', () => {
 
       const bee = new BeeDebug(MOCK_SERVER_URL)
       await expect(bee.cashoutLastCheque(testAddress, { gasPrice: BigInt('100000000000') })).resolves.toEqual(
-        CASHOUT_RESPONSE,
+        TRANSACTION_HASH,
       )
       assertAllIsDone()
     })
@@ -59,7 +59,7 @@ describe('BeeDebug class', () => {
 
       const bee = new BeeDebug(MOCK_SERVER_URL)
       await expect(bee.cashoutLastCheque(testAddress, { gasLimit: BigInt('100000000000') })).resolves.toEqual(
-        CASHOUT_RESPONSE,
+        TRANSACTION_HASH,
       )
       assertAllIsDone()
     })

--- a/test/unit/nock.ts
+++ b/test/unit/nock.ts
@@ -9,6 +9,7 @@ export const MOCK_SERVER_URL = 'http://localhost:12345/'
 const FEED_ENDPOINT = '/feeds'
 const BYTES_ENDPOINT = '/bytes'
 const POSTAGE_ENDPOINT = '/stamps'
+const CHEQUEBOOK_ENDPOINT = '/chequebook'
 
 export function assertAllIsDone(): void {
   if (!nock.isDone()) {
@@ -53,4 +54,20 @@ export function createPostageBatchMock(
   } else {
     return nockMock
   }
+}
+
+export function cashoutLastChequeMock(peer: string, gasPrice?: string, gasLimit?: string): nock.Interceptor {
+  const headers: Record<string, string> = {}
+
+  if (gasPrice) {
+    headers['gas-price'] = gasPrice
+  }
+
+  if (gasLimit) {
+    headers['gas-limit'] = gasLimit
+  }
+
+  return nock(MOCK_SERVER_URL, {
+    reqheaders: headers,
+  }).post(`${CHEQUEBOOK_ENDPOINT}/cashout/${peer}`)
 }


### PR DESCRIPTION
Closes #310 

Honestly, I would like to refactor the `cashoutLastCheque` to return the `transactionHash` directly and not wrapped in an object as is now, but it would be breaking change. What do you think? 