### PR TITLE
feat: request options

### DIFF
--- a/src/bee-debug.ts
+++ b/src/bee-debug.ts
@@ -86,7 +86,9 @@ export class BeeDebug {
 
     const kyOptions: KyOptions = {
       prefixUrl: this.url,
-      timeout: false,
+      timeout: options?.timeout ?? false,
+      retry: options?.retry,
+      fetch: options?.fetch,
       hooks: {
         beforeRequest: [],
         afterResponse: [],
@@ -289,7 +291,6 @@ export class BeeDebug {
    * @param options.gasLimit Gas limit for the cashout transaction in WEI
    */
   async cashoutLastCheque(address: string | Address, options?: CashoutOptions): Promise<string> {
-    assertRequestOptions(options)
     assertCashoutOptions(options)
     assertAddress(address)
 

--- a/src/bee-debug.ts
+++ b/src/bee-debug.ts
@@ -39,6 +39,7 @@ import {
   assertBatchId,
   assertBoolean,
   assertNonNegativeInteger,
+  assertRequestOptions,
   assertTransactionHash,
   isTag,
 } from './utils/type'
@@ -47,6 +48,7 @@ import {
   BeeOptions,
   CashoutOptions,
   PostageBatchOptions,
+  RequestOptions,
   STAMPS_DEPTH_MAX,
   STAMPS_DEPTH_MIN,
   Tag,
@@ -105,12 +107,16 @@ export class BeeDebug {
     this.ky = makeDefaultKy(kyOptions)
   }
 
-  async getNodeAddresses(): Promise<NodeAddresses> {
-    return connectivity.getNodeAddresses(this.ky)
+  async getNodeAddresses(options?: RequestOptions): Promise<NodeAddresses> {
+    assertRequestOptions(options)
+
+    return connectivity.getNodeAddresses(this.getKy(options))
   }
 
-  async getBlocklist(): Promise<Peer[]> {
-    return connectivity.getBlocklist(this.ky)
+  async getBlocklist(options?: RequestOptions): Promise<Peer[]> {
+    assertRequestOptions(options)
+
+    return connectivity.getBlocklist(this.getKy(options))
   }
 
   /**
@@ -123,7 +129,9 @@ export class BeeDebug {
    * @see [Bee API reference - `GET /tags/{uid}`](https://docs.ethswarm.org/debug-api/#tag/Tag)
    *
    */
-  async retrieveExtendedTag(tagUid: number | Tag): Promise<ExtendedTag> {
+  async retrieveExtendedTag(tagUid: number | Tag, options?: RequestOptions): Promise<ExtendedTag> {
+    assertRequestOptions(options)
+
     if (isTag(tagUid)) {
       tagUid = tagUid.uid
     } else if (typeof tagUid === 'number') {
@@ -132,30 +140,36 @@ export class BeeDebug {
       throw new TypeError('tagUid has to be either Tag or a number (UID)!')
     }
 
-    return tag.retrieveExtendedTag(this.ky, tagUid)
+    return tag.retrieveExtendedTag(this.getKy(options), tagUid)
   }
 
   /**
    * Get list of peers for this node
    */
-  async getPeers(): Promise<Peer[]> {
-    return connectivity.getPeers(this.ky)
+  async getPeers(options?: RequestOptions): Promise<Peer[]> {
+    assertRequestOptions(options)
+
+    return connectivity.getPeers(this.getKy(options))
   }
 
-  async removePeer(peer: string | Address): Promise<RemovePeerResponse> {
+  async removePeer(peer: string | Address, options?: RequestOptions): Promise<RemovePeerResponse> {
+    assertRequestOptions(options)
     assertAddress(peer)
 
-    return connectivity.removePeer(this.ky, peer)
+    return connectivity.removePeer(this.getKy(options), peer)
   }
 
-  async getTopology(): Promise<Topology> {
-    return connectivity.getTopology(this.ky)
+  async getTopology(options?: RequestOptions): Promise<Topology> {
+    assertRequestOptions(options)
+
+    return connectivity.getTopology(this.getKy(options))
   }
 
-  async pingPeer(peer: string | Address): Promise<PingResponse> {
+  async pingPeer(peer: string | Address, options?: RequestOptions): Promise<PingResponse> {
+    assertRequestOptions(options)
     assertAddress(peer)
 
-    return connectivity.pingPeer(this.ky, peer)
+    return connectivity.pingPeer(this.getKy(options), peer)
   }
 
   /*
@@ -165,8 +179,10 @@ export class BeeDebug {
   /**
    * Get the balances with all known peers including prepaid services
    */
-  async getAllBalances(): Promise<BalanceResponse> {
-    return balance.getAllBalances(this.ky)
+  async getAllBalances(options?: RequestOptions): Promise<BalanceResponse> {
+    assertRequestOptions(options)
+
+    return balance.getAllBalances(this.getKy(options))
   }
 
   /**
@@ -174,17 +190,20 @@ export class BeeDebug {
    *
    * @param address Swarm address of peer
    */
-  async getPeerBalance(address: Address | string): Promise<PeerBalance> {
+  async getPeerBalance(address: Address | string, options?: RequestOptions): Promise<PeerBalance> {
+    assertRequestOptions(options)
     assertAddress(address)
 
-    return balance.getPeerBalance(this.ky, address)
+    return balance.getPeerBalance(this.getKy(options), address)
   }
 
   /**
    * Get the past due consumption balances with all known peers
    */
-  async getPastDueConsumptionBalances(): Promise<BalanceResponse> {
-    return balance.getPastDueConsumptionBalances(this.ky)
+  async getPastDueConsumptionBalances(options?: RequestOptions): Promise<BalanceResponse> {
+    assertRequestOptions(options)
+
+    return balance.getPastDueConsumptionBalances(this.getKy(options))
   }
 
   /**
@@ -192,10 +211,11 @@ export class BeeDebug {
    *
    * @param address Swarm address of peer
    */
-  async getPastDueConsumptionPeerBalance(address: Address | string): Promise<PeerBalance> {
+  async getPastDueConsumptionPeerBalance(address: Address | string, options?: RequestOptions): Promise<PeerBalance> {
+    assertRequestOptions(options)
     assertAddress(address)
 
-    return balance.getPastDueConsumptionPeerBalance(this.ky, address)
+    return balance.getPastDueConsumptionPeerBalance(this.getKy(options), address)
   }
 
   /*
@@ -208,22 +228,28 @@ export class BeeDebug {
    * **Warning:** The address is returned with 0x prefix unlike all other calls.
    * https://github.com/ethersphere/bee/issues/1443
    */
-  async getChequebookAddress(): Promise<ChequebookAddressResponse> {
-    return chequebook.getChequebookAddress(this.ky)
+  async getChequebookAddress(options?: RequestOptions): Promise<ChequebookAddressResponse> {
+    assertRequestOptions(options)
+
+    return chequebook.getChequebookAddress(this.getKy(options))
   }
 
   /**
    * Get the balance of the chequebook
    */
-  async getChequebookBalance(): Promise<ChequebookBalanceResponse> {
-    return chequebook.getChequebookBalance(this.ky)
+  async getChequebookBalance(options?: RequestOptions): Promise<ChequebookBalanceResponse> {
+    assertRequestOptions(options)
+
+    return chequebook.getChequebookBalance(this.getKy(options))
   }
 
   /**
    * Get last cheques for all peers
    */
-  async getLastCheques(): Promise<LastChequesResponse> {
-    return chequebook.getLastCheques(this.ky)
+  async getLastCheques(options?: RequestOptions): Promise<LastChequesResponse> {
+    assertRequestOptions(options)
+
+    return chequebook.getLastCheques(this.getKy(options))
   }
 
   /**
@@ -231,10 +257,14 @@ export class BeeDebug {
    *
    * @param address  Swarm address of peer
    */
-  async getLastChequesForPeer(address: Address | string): Promise<LastChequesForPeerResponse> {
+  async getLastChequesForPeer(
+    address: Address | string,
+    options?: RequestOptions,
+  ): Promise<LastChequesForPeerResponse> {
+    assertRequestOptions(options)
     assertAddress(address)
 
-    return chequebook.getLastChequesForPeer(this.ky, address)
+    return chequebook.getLastChequesForPeer(this.getKy(options), address)
   }
 
   /**
@@ -242,10 +272,11 @@ export class BeeDebug {
    *
    * @param address  Swarm address of peer
    */
-  async getLastCashoutAction(address: Address | string): Promise<LastCashoutActionResponse> {
+  async getLastCashoutAction(address: Address | string, options?: RequestOptions): Promise<LastCashoutActionResponse> {
+    assertRequestOptions(options)
     assertAddress(address)
 
-    return chequebook.getLastCashoutAction(this.ky, address)
+    return chequebook.getLastCashoutAction(this.getKy(options), address)
   }
 
   /**
@@ -257,6 +288,7 @@ export class BeeDebug {
    * @param options.gasLimit Gas limit for the cashout transaction in WEI
    */
   async cashoutLastCheque(address: string | Address, options?: CashoutOptions): Promise<string> {
+    assertRequestOptions(options)
     assertAddress(address)
 
     if (options?.gasLimit) {
@@ -267,7 +299,7 @@ export class BeeDebug {
       assertNonNegativeInteger(options.gasPrice)
     }
 
-    return chequebook.cashoutLastCheque(this.ky, address, options)
+    return chequebook.cashoutLastCheque(this.getKy(options), address, options)
   }
 
   /**
@@ -277,14 +309,19 @@ export class BeeDebug {
    * @param gasPrice Gas Price in WEI for the transaction call
    * @return string  Hash of the transaction
    */
-  async depositTokens(amount: number | NumberString, gasPrice?: NumberString): Promise<string> {
+  async depositTokens(
+    amount: number | NumberString,
+    gasPrice?: NumberString,
+    options?: RequestOptions,
+  ): Promise<string> {
+    assertRequestOptions(options)
     assertNonNegativeInteger(amount)
 
     if (gasPrice) {
       assertNonNegativeInteger(gasPrice)
     }
 
-    return chequebook.depositTokens(this.ky, amount, gasPrice)
+    return chequebook.depositTokens(this.getKy(options), amount, gasPrice)
   }
 
   /**
@@ -294,14 +331,19 @@ export class BeeDebug {
    * @param gasPrice Gas Price in WEI for the transaction call
    * @return string  Hash of the transaction
    */
-  async withdrawTokens(amount: number | NumberString, gasPrice?: NumberString): Promise<string> {
+  async withdrawTokens(
+    amount: number | NumberString,
+    gasPrice?: NumberString,
+    options?: RequestOptions,
+  ): Promise<string> {
+    assertRequestOptions(options)
     assertNonNegativeInteger(amount)
 
     if (gasPrice) {
       assertNonNegativeInteger(gasPrice)
     }
 
-    return chequebook.withdrawTokens(this.ky, amount, gasPrice)
+    return chequebook.withdrawTokens(this.getKy(options), amount, gasPrice)
   }
 
   /*
@@ -313,24 +355,29 @@ export class BeeDebug {
    *
    * @param address  Swarm address of peer
    */
-  async getSettlements(address: Address | string): Promise<Settlements> {
+  async getSettlements(address: Address | string, options?: RequestOptions): Promise<Settlements> {
+    assertRequestOptions(options)
     assertAddress(address)
 
-    return settlements.getSettlements(this.ky, address)
+    return settlements.getSettlements(this.getKy(options), address)
   }
 
   /**
    * Get settlements with all known peers and total amount sent or received
    */
-  async getAllSettlements(): Promise<AllSettlements> {
-    return settlements.getAllSettlements(this.ky)
+  async getAllSettlements(options?: RequestOptions): Promise<AllSettlements> {
+    assertRequestOptions(options)
+
+    return settlements.getAllSettlements(this.getKy(options))
   }
 
   /**
    * Get health of node
    */
-  async getHealth(): Promise<Health> {
-    return status.getHealth(this.ky)
+  async getHealth(options?: RequestOptions): Promise<Health> {
+    assertRequestOptions(options)
+
+    return status.getHealth(this.getKy(options))
   }
 
   /**
@@ -338,22 +385,28 @@ export class BeeDebug {
    *
    * @returns true if the Bee node version is supported
    */
-  async isSupportedVersion(): Promise<boolean> | never {
-    return status.isSupportedVersion(this.ky)
+  async isSupportedVersion(options?: RequestOptions): Promise<boolean> | never {
+    assertRequestOptions(options)
+
+    return status.isSupportedVersion(this.getKy(options))
   }
 
   /**
    * Get reserve state
    */
-  async getReserveState(): Promise<ReserveState> {
-    return states.getReserveState(this.ky)
+  async getReserveState(options?: RequestOptions): Promise<ReserveState> {
+    assertRequestOptions(options)
+
+    return states.getReserveState(this.getKy(options))
   }
 
   /**
    * Get chain state
    */
-  async getChainState(): Promise<ChainState> {
-    return states.getChainState(this.ky)
+  async getChainState(options?: RequestOptions): Promise<ChainState> {
+    assertRequestOptions(options)
+
+    return states.getChainState(this.getKy(options))
   }
 
   /**
@@ -374,6 +427,7 @@ export class BeeDebug {
    * @see [Bee Debug API reference - `POST /stamps`](https://docs.ethswarm.org/debug-api/#tag/Postage-Stamps/paths/~1stamps~1{amount}~1{depth}/post)
    */
   async createPostageBatch(amount: NumberString, depth: number, options?: PostageBatchOptions): Promise<BatchId> {
+    assertRequestOptions(options)
     assertNonNegativeInteger(amount)
     assertNonNegativeInteger(depth)
 
@@ -393,7 +447,7 @@ export class BeeDebug {
       assertBoolean(options.immutableFlag)
     }
 
-    return stamps.createPostageBatch(this.ky, amount, depth, options)
+    return stamps.createPostageBatch(this.getKy(options), amount, depth, options)
   }
 
   /**
@@ -404,10 +458,11 @@ export class BeeDebug {
    * @see [Bee docs - Keep your data alive / Postage stamps](https://docs.ethswarm.org/docs/access-the-swarm/keep-your-data-alive)
    * @see [Bee Debug API reference - `GET /stamps/${id}`](https://docs.ethswarm.org/debug-api/#tag/Postage-Stamps/paths/~1stamps~1{id}/get)
    */
-  async getPostageBatch(postageBatchId: BatchId | string): Promise<DebugPostageBatch> {
+  async getPostageBatch(postageBatchId: BatchId | string, options?: RequestOptions): Promise<DebugPostageBatch> {
+    assertRequestOptions(options)
     assertBatchId(postageBatchId)
 
-    return stamps.getPostageBatch(this.ky, postageBatchId)
+    return stamps.getPostageBatch(this.getKy(options), postageBatchId)
   }
 
   /**
@@ -418,10 +473,14 @@ export class BeeDebug {
    * @see [Bee docs - Keep your data alive / Postage stamps](https://docs.ethswarm.org/docs/access-the-swarm/keep-your-data-alive)
    * @see [Bee Debug API reference - `GET /stamps/${id}/buckets`](https://docs.ethswarm.org/debug-api/#tag/Postage-Stamps/paths/~1stamps~1{id}~1buckets/get)
    */
-  async getPostageBatchBuckets(postageBatchId: BatchId | string): Promise<PostageBatchBuckets> {
+  async getPostageBatchBuckets(
+    postageBatchId: BatchId | string,
+    options?: RequestOptions,
+  ): Promise<PostageBatchBuckets> {
+    assertRequestOptions(options)
     assertBatchId(postageBatchId)
 
-    return stamps.getPostageBatchBuckets(this.ky, postageBatchId)
+    return stamps.getPostageBatchBuckets(this.getKy(options), postageBatchId)
   }
 
   /**
@@ -430,25 +489,33 @@ export class BeeDebug {
    * @see [Bee docs - Keep your data alive / Postage stamps](https://docs.ethswarm.org/docs/access-the-swarm/keep-your-data-alive)
    * @see [Bee Debug API reference - `GET /stamps`](https://docs.ethswarm.org/debug-api/#tag/Postage-Stamps/paths/~1stamps/get)
    */
-  async getAllPostageBatch(): Promise<DebugPostageBatch[]> {
-    return stamps.getAllPostageBatches(this.ky)
+  async getAllPostageBatch(options?: RequestOptions): Promise<DebugPostageBatch[]> {
+    assertRequestOptions(options)
+
+    return stamps.getAllPostageBatches(this.getKy(options))
   }
 
   /**
    * Return lists of all current pending transactions that the Bee made
    */
-  async getAllPendingTransactions(): Promise<TransactionInfo[]> {
-    return transactions.getAllTransactions(this.ky)
+  async getAllPendingTransactions(options?: RequestOptions): Promise<TransactionInfo[]> {
+    assertRequestOptions(options)
+
+    return transactions.getAllTransactions(this.getKy(options))
   }
 
   /**
    * Return transaction information for specific transaction
    * @param transactionHash
    */
-  async getPendingTransaction(transactionHash: TransactionHash | string): Promise<TransactionInfo> {
+  async getPendingTransaction(
+    transactionHash: TransactionHash | string,
+    options?: RequestOptions,
+  ): Promise<TransactionInfo> {
+    assertRequestOptions(options)
     assertTransactionHash(transactionHash)
 
-    return transactions.getTransaction(this.ky, transactionHash)
+    return transactions.getTransaction(this.getKy(options), transactionHash)
   }
 
   /**
@@ -457,10 +524,14 @@ export class BeeDebug {
    *
    * @param transactionHash
    */
-  async rebroadcastPendingTransaction(transactionHash: TransactionHash | string): Promise<TransactionHash> {
+  async rebroadcastPendingTransaction(
+    transactionHash: TransactionHash | string,
+    options?: RequestOptions,
+  ): Promise<TransactionHash> {
+    assertRequestOptions(options)
     assertTransactionHash(transactionHash)
 
-    return transactions.rebroadcastTransaction(this.ky, transactionHash)
+    return transactions.rebroadcastTransaction(this.getKy(options), transactionHash)
   }
 
   /**
@@ -471,13 +542,23 @@ export class BeeDebug {
   async cancelPendingTransaction(
     transactionHash: TransactionHash | string,
     gasPrice?: NumberString,
+    options?: RequestOptions,
   ): Promise<TransactionHash> {
+    assertRequestOptions(options)
     assertTransactionHash(transactionHash)
 
     if (gasPrice) {
       assertNonNegativeInteger(gasPrice)
     }
 
-    return transactions.cancelTransaction(this.ky, transactionHash, gasPrice)
+    return transactions.cancelTransaction(this.getKy(options), transactionHash, gasPrice)
+  }
+
+  private getKy(options?: RequestOptions): Ky {
+    if (!options) {
+      return this.ky
+    }
+
+    return this.ky.extend(options)
   }
 }

--- a/src/bee-debug.ts
+++ b/src/bee-debug.ts
@@ -38,6 +38,7 @@ import {
   assertAddress,
   assertBatchId,
   assertBoolean,
+  assertCashoutOptions,
   assertNonNegativeInteger,
   assertRequestOptions,
   assertTransactionHash,
@@ -289,15 +290,8 @@ export class BeeDebug {
    */
   async cashoutLastCheque(address: string | Address, options?: CashoutOptions): Promise<string> {
     assertRequestOptions(options)
+    assertCashoutOptions(options)
     assertAddress(address)
-
-    if (options?.gasLimit) {
-      assertNonNegativeInteger(options.gasLimit)
-    }
-
-    if (options?.gasPrice) {
-      assertNonNegativeInteger(options.gasPrice)
-    }
 
     return chequebook.cashoutLastCheque(this.getKy(options), address, options)
   }

--- a/src/bee.ts
+++ b/src/bee.ts
@@ -122,7 +122,9 @@ export class Bee {
 
     const kyOptions: KyOptions = {
       prefixUrl: this.url,
-      timeout: false,
+      timeout: options?.timeout ?? false,
+      retry: options?.retry,
+      fetch: options?.fetch,
       hooks: {
         beforeRequest: [],
         afterResponse: [],

--- a/src/bee.ts
+++ b/src/bee.ts
@@ -32,6 +32,7 @@ import {
   assertPssMessageHandler,
   assertPublicKey,
   assertReference,
+  assertRequestOptions,
   assertUploadOptions,
   makeTagUid,
 } from './utils/type'
@@ -44,6 +45,7 @@ import {
   NumberString,
   PostageBatchOptions,
   Readable,
+  RequestOptions,
   STAMPS_DEPTH_MAX,
   STAMPS_DEPTH_MIN,
   UploadResult,
@@ -163,7 +165,7 @@ export class Bee {
 
     if (options) assertUploadOptions(options)
 
-    return bytes.upload(this.ky, data, postageBatchId, options)
+    return bytes.upload(this.getKy(options), data, postageBatchId, options)
   }
 
   /**
@@ -173,10 +175,11 @@ export class Bee {
    * @see [Bee docs - Upload and download](https://docs.ethswarm.org/docs/access-the-swarm/upload-and-download)
    * @see [Bee API reference - `GET /bytes`](https://docs.ethswarm.org/api/#tag/Bytes/paths/~1bytes~1{reference}/get)
    */
-  async downloadData(reference: Reference | string): Promise<Data> {
+  async downloadData(reference: Reference | string, options?: RequestOptions): Promise<Data> {
+    assertRequestOptions(options)
     assertReference(reference)
 
-    return bytes.download(this.ky, reference)
+    return bytes.download(this.getKy(options), reference)
   }
 
   /**
@@ -186,10 +189,14 @@ export class Bee {
    * @see [Bee docs - Upload and download](https://docs.ethswarm.org/docs/access-the-swarm/upload-and-download)
    * @see [Bee API reference - `GET /bytes`](https://docs.ethswarm.org/api/#tag/Bytes/paths/~1bytes~1{reference}/get)
    */
-  async downloadReadableData(reference: Reference | string): Promise<ReadableStream<Uint8Array>> {
+  async downloadReadableData(
+    reference: Reference | string,
+    options?: RequestOptions,
+  ): Promise<ReadableStream<Uint8Array>> {
+    assertRequestOptions(options)
     assertReference(reference)
 
-    return bytes.downloadReadable(this.ky, reference)
+    return bytes.downloadReadable(this.getKy(options), reference)
   }
 
   /**
@@ -229,15 +236,15 @@ export class Bee {
       const contentType = data.type
       const fileOptions = { contentType, ...options }
 
-      return bzz.uploadFile(this.ky, fileData, postageBatchId, fileName, fileOptions)
+      return bzz.uploadFile(this.getKy(options), fileData, postageBatchId, fileName, fileOptions)
     } else if (isReadable(data) && options?.tag && !options.size) {
       // TODO: Needed until https://github.com/ethersphere/bee/issues/2317 is resolved
-      const result = await bzz.uploadFile(this.ky, data, postageBatchId, name, options)
+      const result = await bzz.uploadFile(this.getKy(options), data, postageBatchId, name, options)
       await this.updateTag(options.tag, result.reference)
 
       return result
     } else {
-      return bzz.uploadFile(this.ky, data, postageBatchId, name, options)
+      return bzz.uploadFile(this.getKy(options), data, postageBatchId, name, options)
     }
   }
 
@@ -251,10 +258,11 @@ export class Bee {
    * @see [Bee docs - Upload and download](https://docs.ethswarm.org/docs/access-the-swarm/upload-and-download)
    * @see [Bee API reference - `GET /bzz`](https://docs.ethswarm.org/api/#tag/Collection/paths/~1bzz~1{reference}~1{path}/get)
    */
-  async downloadFile(reference: Reference | string, path = ''): Promise<FileData<Data>> {
+  async downloadFile(reference: Reference | string, path = '', options?: RequestOptions): Promise<FileData<Data>> {
+    assertRequestOptions(options)
     assertReference(reference)
 
-    return bzz.downloadFile(this.ky, reference, path)
+    return bzz.downloadFile(this.getKy(options), reference, path)
   }
 
   /**
@@ -266,10 +274,15 @@ export class Bee {
    * @see [Bee docs - Upload and download](https://docs.ethswarm.org/docs/access-the-swarm/upload-and-download)
    * @see [Bee API reference - `GET /bzz`](https://docs.ethswarm.org/api/#tag/Collection/paths/~1bzz~1{reference}~1{path}/get)
    */
-  async downloadReadableFile(reference: Reference | string, path = ''): Promise<FileData<ReadableStream<Uint8Array>>> {
+  async downloadReadableFile(
+    reference: Reference | string,
+    path = '',
+    options?: RequestOptions,
+  ): Promise<FileData<ReadableStream<Uint8Array>>> {
+    assertRequestOptions(options)
     assertReference(reference)
 
-    return bzz.downloadFileReadable(this.ky, reference, path)
+    return bzz.downloadFileReadable(this.getKy(options), reference, path)
   }
 
   /**
@@ -299,7 +312,7 @@ export class Bee {
 
     const data = await makeCollectionFromFileList(fileList)
 
-    return bzz.uploadCollection(this.ky, data, postageBatchId, options)
+    return bzz.uploadCollection(this.getKy(options), data, postageBatchId, options)
   }
 
   /**
@@ -351,7 +364,7 @@ export class Bee {
     if (options) assertCollectionUploadOptions(options)
     const data = await makeCollectionFromFS(dir)
 
-    return bzz.uploadCollection(this.ky, data, postageBatchId, options)
+    return bzz.uploadCollection(this.getKy(options), data, postageBatchId, options)
   }
 
   /**
@@ -362,8 +375,10 @@ export class Bee {
    * @see [Bee docs - Syncing / Tags](https://docs.ethswarm.org/docs/access-the-swarm/syncing)
    * @see [Bee API reference - `POST /tags`](https://docs.ethswarm.org/api/#tag/Tag/paths/~1tags/post)
    */
-  async createTag(): Promise<Tag> {
-    return tag.createTag(this.ky)
+  async createTag(options?: RequestOptions): Promise<Tag> {
+    assertRequestOptions(options)
+
+    return tag.createTag(this.getKy(options))
   }
 
   /**
@@ -381,9 +396,10 @@ export class Bee {
    * @see [Bee API reference - `GET /tags`](https://docs.ethswarm.org/api/#tag/Tag/paths/~1tags/get)
    */
   async getAllTags(options?: AllTagsOptions): Promise<Tag[]> {
+    assertRequestOptions(options)
     assertAllTagsOptions(options)
 
-    return tag.getAllTags(this.ky, options?.offset, options?.limit)
+    return tag.getAllTags(this.getKy(options), options?.offset, options?.limit)
   }
 
   /**
@@ -398,10 +414,12 @@ export class Bee {
    * @see [Bee API reference - `GET /tags/{uid}`](https://docs.ethswarm.org/api/#tag/Tag/paths/~1tags~1{uid}/get)
    *
    */
-  async retrieveTag(tagUid: number | Tag): Promise<Tag> {
+  async retrieveTag(tagUid: number | Tag, options?: RequestOptions): Promise<Tag> {
+    assertRequestOptions(options)
+
     tagUid = makeTagUid(tagUid)
 
-    return tag.retrieveTag(this.ky, tagUid)
+    return tag.retrieveTag(this.getKy(options), tagUid)
   }
 
   /**
@@ -416,10 +434,12 @@ export class Bee {
    * @see [Bee docs - Syncing / Tags](https://docs.ethswarm.org/docs/access-the-swarm/syncing)
    * @see [Bee API reference - `DELETE /tags/{uid}`](https://docs.ethswarm.org/api/#tag/Tag/paths/~1tags~1{uid}/delete)
    */
-  async deleteTag(tagUid: number | Tag): Promise<void> {
+  async deleteTag(tagUid: number | Tag, options?: RequestOptions): Promise<void> {
+    assertRequestOptions(options)
+
     tagUid = makeTagUid(tagUid)
 
-    return tag.deleteTag(this.ky, tagUid)
+    return tag.deleteTag(this.getKy(options), tagUid)
   }
 
   /**
@@ -438,11 +458,13 @@ export class Bee {
    * @see [Bee docs - Syncing / Tags](https://docs.ethswarm.org/docs/access-the-swarm/syncing)
    * @see [Bee API reference - `PATCH /tags/{uid}`](https://docs.ethswarm.org/api/#tag/Tag/paths/~1tags~1{uid}/patch)
    */
-  async updateTag(tagUid: number | Tag, reference: Reference | string): Promise<void> {
+  async updateTag(tagUid: number | Tag, reference: Reference | string, options?: RequestOptions): Promise<void> {
     assertReference(reference)
+    assertRequestOptions(options)
+
     tagUid = makeTagUid(tagUid)
 
-    return tag.updateTag(this.ky, tagUid, reference)
+    return tag.updateTag(this.getKy(options), tagUid, reference)
   }
 
   /**
@@ -455,10 +477,11 @@ export class Bee {
    *
    * @see [Bee docs - Pinning](https://docs.ethswarm.org/docs/access-the-swarm/pinning)
    */
-  async pin(reference: Reference | string): Promise<void> {
+  async pin(reference: Reference | string, options?: RequestOptions): Promise<void> {
+    assertRequestOptions(options)
     assertReference(reference)
 
-    return pinning.pin(this.ky, reference)
+    return pinning.pin(this.getKy(options), reference)
   }
 
   /**
@@ -471,10 +494,11 @@ export class Bee {
    *
    * @see [Bee docs - Pinning](https://docs.ethswarm.org/docs/access-the-swarm/pinning)
    */
-  async unpin(reference: Reference | string): Promise<void> {
+  async unpin(reference: Reference | string, options?: RequestOptions): Promise<void> {
+    assertRequestOptions(options)
     assertReference(reference)
 
-    return pinning.unpin(this.ky, reference)
+    return pinning.unpin(this.getKy(options), reference)
   }
 
   /**
@@ -484,8 +508,10 @@ export class Bee {
    *
    * @see [Bee docs - Pinning](https://docs.ethswarm.org/docs/access-the-swarm/pinning)
    */
-  async getAllPins(): Promise<Reference[]> {
-    return pinning.getAllPins(this.ky)
+  async getAllPins(options?: RequestOptions): Promise<Reference[]> {
+    assertRequestOptions(options)
+
+    return pinning.getAllPins(this.getKy(options))
   }
 
   /**
@@ -498,10 +524,11 @@ export class Bee {
    *
    * @see [Bee docs - Pinning](https://docs.ethswarm.org/docs/access-the-swarm/pinning)
    */
-  async getPin(reference: Reference | string): Promise<Pin> {
+  async getPin(reference: Reference | string, options?: RequestOptions): Promise<Pin> {
+    assertRequestOptions(options)
     assertReference(reference)
 
-    return pinning.getPin(this.ky, reference)
+    return pinning.getPin(this.getKy(options), reference)
   }
 
   /**
@@ -511,7 +538,8 @@ export class Bee {
    * @throws BeeArgumentError if the reference is not locally pinned
    * @throws TypeError if reference is in not correct format
    */
-  async reuploadPinnedData(reference: Reference | string): Promise<void> {
+  async reuploadPinnedData(reference: Reference | string, options?: RequestOptions): Promise<void> {
+    assertRequestOptions(options)
     assertReference(reference)
 
     try {
@@ -524,7 +552,7 @@ export class Bee {
       }
     }
 
-    await stewardship.reupload(this.ky, reference)
+    await stewardship.reupload(this.getKy(options), reference)
   }
 
   /**
@@ -556,7 +584,9 @@ export class Bee {
     target: AddressPrefix,
     data: string | Uint8Array,
     recipient?: string | PublicKey,
+    options?: RequestOptions,
   ): Promise<void> {
+    assertRequestOptions(options)
     assertData(data)
     assertBatchId(postageBatchId)
     assertAddressPrefix(target)
@@ -568,9 +598,9 @@ export class Bee {
     if (recipient) {
       assertPublicKey(recipient)
 
-      return pss.send(this.ky, topic, target, data, postageBatchId, recipient)
+      return pss.send(this.getKy(options), topic, target, data, postageBatchId, recipient)
     } else {
-      return pss.send(this.ky, topic, target, data, postageBatchId)
+      return pss.send(this.getKy(options), topic, target, data, postageBatchId)
     }
   }
 
@@ -714,14 +744,16 @@ export class Bee {
     type: FeedType,
     topic: Topic | Uint8Array | string,
     owner: EthAddress | Uint8Array | string,
+    options?: RequestOptions,
   ): Promise<Reference> {
+    assertRequestOptions(options)
     assertFeedType(type)
     assertBatchId(postageBatchId)
 
     const canonicalTopic = makeTopic(topic)
     const canonicalOwner = makeHexEthAddress(owner)
 
-    return createFeedManifest(this.ky, canonicalOwner, canonicalTopic, postageBatchId, { type })
+    return createFeedManifest(this.getKy(options), canonicalOwner, canonicalTopic, postageBatchId, { type })
   }
 
   /**
@@ -737,13 +769,15 @@ export class Bee {
     type: FeedType,
     topic: Topic | Uint8Array | string,
     owner: EthAddress | Uint8Array | string,
+    options?: RequestOptions,
   ): FeedReader {
+    assertRequestOptions(options)
     assertFeedType(type)
 
     const canonicalTopic = makeTopic(topic)
     const canonicalOwner = makeHexEthAddress(owner)
 
-    return makeFeedReader(this.ky, type, canonicalTopic, canonicalOwner)
+    return makeFeedReader(this.getKy(options), type, canonicalTopic, canonicalOwner)
   }
 
   /**
@@ -759,13 +793,15 @@ export class Bee {
     type: FeedType,
     topic: Topic | Uint8Array | string,
     signer?: Signer | Uint8Array | string,
+    options?: RequestOptions,
   ): FeedWriter {
+    assertRequestOptions(options)
     assertFeedType(type)
 
     const canonicalTopic = makeTopic(topic)
     const canonicalSigner = this.resolveSigner(signer)
 
-    return makeFeedWriter(this.ky, type, canonicalTopic, canonicalSigner)
+    return makeFeedWriter(this.getKy(options), type, canonicalTopic, canonicalSigner)
   }
 
   /**
@@ -792,13 +828,14 @@ export class Bee {
     data: T,
     options?: JsonFeedOptions,
   ): Promise<Reference> {
+    assertRequestOptions(options, 'JsonFeedOptions')
     assertBatchId(postageBatchId)
 
     const hashedTopic = this.makeFeedTopic(topic)
     const feedType = options?.type ?? DEFAULT_FEED_TYPE
-    const writer = this.makeFeedWriter(feedType, hashedTopic, options?.signer)
+    const writer = this.makeFeedWriter(feedType, hashedTopic, options?.signer, options)
 
-    return setJsonData(this, writer, postageBatchId, data)
+    return setJsonData(this, writer, postageBatchId, data, options)
   }
 
   /**
@@ -821,6 +858,8 @@ export class Bee {
    * @see [Bee docs - Feeds](https://docs.ethswarm.org/docs/dapps-on-swarm/feeds)
    */
   async getJsonFeed<T extends AnyJson>(topic: string, options?: JsonFeedOptions): Promise<T> {
+    assertRequestOptions(options, 'JsonFeedOptions')
+
     const hashedTopic = this.makeFeedTopic(topic)
     const feedType = options?.type ?? DEFAULT_FEED_TYPE
 
@@ -844,7 +883,7 @@ export class Bee {
       }
     }
 
-    const reader = this.makeFeedReader(feedType, hashedTopic, address)
+    const reader = this.makeFeedReader(feedType, hashedTopic, address, options)
 
     return getJsonData(this, reader)
   }
@@ -868,11 +907,12 @@ export class Bee {
    *
    * @see [Bee docs - Chunk Types](https://docs.ethswarm.org/docs/dapps-on-swarm/chunk-types#single-owner-chunks)
    */
-  makeSOCReader(ownerAddress: EthAddress | Uint8Array | string): SOCReader {
+  makeSOCReader(ownerAddress: EthAddress | Uint8Array | string, options?: RequestOptions): SOCReader {
+    assertRequestOptions(options)
     const canonicalOwner = makeEthAddress(ownerAddress)
 
     return {
-      download: downloadSingleOwnerChunk.bind(null, this.ky, canonicalOwner),
+      download: downloadSingleOwnerChunk.bind(null, this.getKy(options), canonicalOwner),
     }
   }
 
@@ -883,13 +923,14 @@ export class Bee {
    *
    * @see [Bee docs - Chunk Types](https://docs.ethswarm.org/docs/dapps-on-swarm/chunk-types#single-owner-chunks)
    */
-  makeSOCWriter(signer?: Signer | Uint8Array | string): SOCWriter {
+  makeSOCWriter(signer?: Signer | Uint8Array | string, options?: RequestOptions): SOCWriter {
+    assertRequestOptions(options)
     const canonicalSigner = this.resolveSigner(signer)
 
     return {
-      ...this.makeSOCReader(canonicalSigner.address),
+      ...this.makeSOCReader(canonicalSigner.address, options),
 
-      upload: uploadSingleOwnerChunkData.bind(null, this.ky, canonicalSigner),
+      upload: uploadSingleOwnerChunkData.bind(null, this.getKy(options), canonicalSigner),
     }
   }
 
@@ -913,6 +954,7 @@ export class Bee {
    * @deprecated Use DebugBee for postage batch management
    */
   async createPostageBatch(amount: NumberString, depth: number, options?: PostageBatchOptions): Promise<BatchId> {
+    assertRequestOptions(options, 'PostageBatchOptions')
     assertNonNegativeInteger(amount)
     assertNonNegativeInteger(depth)
 
@@ -932,7 +974,7 @@ export class Bee {
       assertBoolean(options.immutableFlag)
     }
 
-    return stamps.createPostageBatch(this.ky, amount, depth, options)
+    return stamps.createPostageBatch(this.getKy(options), amount, depth, options)
   }
 
   /**
@@ -946,10 +988,10 @@ export class Bee {
    * @see [Bee API reference - `GET /stamps/${id}`](https://docs.ethswarm.org/api/#tag/Postage-Stamps/paths/~1stamps~1{id}/get)
    * @deprecated Use DebugBee for postage batch management
    */
-  async getPostageBatch(postageBatchId: BatchId | string): Promise<PostageBatch> {
+  async getPostageBatch(postageBatchId: BatchId | string, options?: RequestOptions): Promise<PostageBatch> {
     assertBatchId(postageBatchId)
 
-    return stamps.getPostageBatch(this.ky, postageBatchId)
+    return stamps.getPostageBatch(this.getKy(options), postageBatchId)
   }
 
   /**
@@ -961,8 +1003,8 @@ export class Bee {
    * @see [Bee API reference - `GET /stamps`](https://docs.ethswarm.org/api/#tag/Postage-Stamps/paths/~1stamps/get)
    * @deprecated Use DebugBee for postage batch management
    */
-  async getAllPostageBatch(): Promise<PostageBatch[]> {
-    return stamps.getAllPostageBatches(this.ky)
+  async getAllPostageBatch(options?: RequestOptions): Promise<PostageBatch[]> {
+    return stamps.getAllPostageBatches(this.getKy(options))
   }
 
   /**
@@ -970,8 +1012,8 @@ export class Bee {
    *
    * @throws If connection was not successful throw error
    */
-  async checkConnection(): Promise<void> | never {
-    return status.checkConnection(this.ky)
+  async checkConnection(options?: RequestOptions): Promise<void> | never {
+    return status.checkConnection(this.getKy(options))
   }
 
   /**
@@ -979,9 +1021,9 @@ export class Bee {
    *
    * @returns true if successful, false on error
    */
-  async isConnected(): Promise<boolean> {
+  async isConnected(options?: RequestOptions): Promise<boolean> {
     try {
-      await status.checkConnection(this.ky)
+      await status.checkConnection(this.getKy(options))
     } catch (e) {
       return false
     }
@@ -1004,5 +1046,13 @@ export class Bee {
     }
 
     throw new BeeError('You have to pass Signer as property to either the method call or constructor! Non found.')
+  }
+
+  private getKy(options?: RequestOptions): Ky {
+    if (!options) {
+      return this.ky
+    }
+
+    return this.ky.extend(options)
   }
 }

--- a/src/bee.ts
+++ b/src/bee.ts
@@ -23,12 +23,12 @@ import {
   assertAddressPrefix,
   assertAllTagsOptions,
   assertBatchId,
-  assertBoolean,
   assertCollectionUploadOptions,
   assertData,
   assertFileData,
   assertFileUploadOptions,
   assertNonNegativeInteger,
+  assertPostageBatchOptions,
   assertPssMessageHandler,
   assertPublicKey,
   assertReference,
@@ -149,7 +149,7 @@ export class Bee {
    *
    * @param postageBatchId Postage BatchId to be used to upload the data with
    * @param data    Data to be uploaded
-   * @param options Additional options like tag, encryption, pinning, content-type
+   * @param options Additional options like tag, encryption, pinning, content-type and request options
    *
    * @returns reference is a content hash of the data
    * @see [Bee docs - Upload and download](https://docs.ethswarm.org/docs/access-the-swarm/upload-and-download)
@@ -172,6 +172,7 @@ export class Bee {
    * Download data as a byte array
    *
    * @param reference Bee data reference
+   * @param options Options that affects the request behavior
    * @see [Bee docs - Upload and download](https://docs.ethswarm.org/docs/access-the-swarm/upload-and-download)
    * @see [Bee API reference - `GET /bytes`](https://docs.ethswarm.org/api/#tag/Bytes/paths/~1bytes~1{reference}/get)
    */
@@ -186,6 +187,7 @@ export class Bee {
    * Download data as a Readable stream
    *
    * @param reference Bee data reference
+   * @param options Options that affects the request behavior
    * @see [Bee docs - Upload and download](https://docs.ethswarm.org/docs/access-the-swarm/upload-and-download)
    * @see [Bee API reference - `GET /bytes`](https://docs.ethswarm.org/api/#tag/Bytes/paths/~1bytes~1{reference}/get)
    */
@@ -208,7 +210,7 @@ export class Bee {
    * @param postageBatchId Postage BatchId to be used to upload the data with
    * @param data    Data or file to be uploaded
    * @param name    Optional name of the uploaded file
-   * @param options Additional options like tag, encryption, pinning, content-type
+   * @param options Additional options like tag, encryption, pinning, content-type and request options
    *
    * @see [Bee docs - Keep your data alive / Postage stamps](https://docs.ethswarm.org/docs/access-the-swarm/keep-your-data-alive)
    * @see [Bee docs - Upload and download](https://docs.ethswarm.org/docs/access-the-swarm/upload-and-download)
@@ -253,6 +255,7 @@ export class Bee {
    *
    * @param reference Bee file reference
    * @param path If reference points to manifest, then this parameter defines path to the file
+   * @param options Options that affects the request behavior
    *
    * @see Data
    * @see [Bee docs - Upload and download](https://docs.ethswarm.org/docs/access-the-swarm/upload-and-download)
@@ -270,6 +273,7 @@ export class Bee {
    *
    * @param reference Hash reference to file
    * @param path If reference points to manifest / collections, then this parameter defines path to the file
+   * @param options Options that affects the request behavior
    *
    * @see [Bee docs - Upload and download](https://docs.ethswarm.org/docs/access-the-swarm/upload-and-download)
    * @see [Bee API reference - `GET /bzz`](https://docs.ethswarm.org/api/#tag/Collection/paths/~1bzz~1{reference}~1{path}/get)
@@ -295,7 +299,7 @@ export class Bee {
    *
    * @param postageBatchId Postage BatchId to be used to upload the data with
    * @param fileList list of files to be uploaded
-   * @param options Additional options like tag, encryption, pinning
+   * @param options Additional options like tag, encryption, pinning and request options
    *
    * @see [Bee docs - Keep your data alive / Postage stamps](https://docs.ethswarm.org/docs/access-the-swarm/keep-your-data-alive)
    * @see [Bee docs - Upload directory](https://docs.ethswarm.org/docs/access-the-swarm/upload-a-directory/)
@@ -323,7 +327,7 @@ export class Bee {
    *
    * @param postageBatchId
    * @param collection
-   * @param options
+   * @param options Collections and request options
    */
   async uploadCollection(
     postageBatchId: string | BatchId,
@@ -348,7 +352,7 @@ export class Bee {
    *
    * @param postageBatchId Postage BatchId to be used to upload the data with
    * @param dir the path of the files to be uploaded
-   * @param options Additional options like tag, encryption, pinning
+   * @param options Additional options like tag, encryption, pinning and request options
    *
    * @see [Bee docs - Keep your data alive / Postage stamps](https://docs.ethswarm.org/docs/access-the-swarm/keep-your-data-alive)
    * @see [Bee docs - Upload directory](https://docs.ethswarm.org/docs/access-the-swarm/upload-a-directory/)
@@ -372,6 +376,7 @@ export class Bee {
    *
    * **Warning! Not allowed when node is in Gateway mode!**
    *
+   * @param options Options that affects the request behavior
    * @see [Bee docs - Syncing / Tags](https://docs.ethswarm.org/docs/access-the-swarm/syncing)
    * @see [Bee API reference - `POST /tags`](https://docs.ethswarm.org/api/#tag/Tag/paths/~1tags/post)
    */
@@ -388,7 +393,7 @@ export class Bee {
    *
    * **Warning! Not allowed when node is in Gateway mode!**
    *
-   * @param options
+   * @param options Options that affects the request behavior
    * @throws TypeError if limit or offset are not numbers or undefined
    * @throws BeeArgumentError if limit or offset have invalid options
    *
@@ -408,6 +413,7 @@ export class Bee {
    * **Warning! Not allowed when node is in Gateway mode!**
    *
    * @param tagUid UID or tag object to be retrieved
+   * @param options Options that affects the request behavior
    * @throws TypeError if tagUid is in not correct format
    *
    * @see [Bee docs - Syncing / Tags](https://docs.ethswarm.org/docs/access-the-swarm/syncing)
@@ -428,6 +434,7 @@ export class Bee {
    * **Warning! Not allowed when node is in Gateway mode!**
    *
    * @param tagUid UID or tag object to be retrieved
+   * @param options Options that affects the request behavior
    * @throws TypeError if tagUid is in not correct format
    * @throws BeeResponse error if something went wrong on the Bee node side while deleting the tag.
    *
@@ -452,6 +459,7 @@ export class Bee {
    *
    * @param tagUid UID or tag object to be retrieved
    * @param reference The root reference that contains all the chunks to be counted
+   * @param options Options that affects the request behavior
    * @throws TypeError if tagUid is in not correct format
    * @throws BeeResponse error if something went wrong on the Bee node side while deleting the tag.
    *
@@ -473,6 +481,7 @@ export class Bee {
    * **Warning! Not allowed when node is in Gateway mode!**
    *
    * @param reference Data reference
+   * @param options Options that affects the request behavior
    * @throws TypeError if reference is in not correct format
    *
    * @see [Bee docs - Pinning](https://docs.ethswarm.org/docs/access-the-swarm/pinning)
@@ -490,6 +499,7 @@ export class Bee {
    * **Warning! Not allowed when node is in Gateway mode!**
    *
    * @param reference Data reference
+   * @param options Options that affects the request behavior
    * @throws TypeError if reference is in not correct format
    *
    * @see [Bee docs - Pinning](https://docs.ethswarm.org/docs/access-the-swarm/pinning)
@@ -506,6 +516,7 @@ export class Bee {
    *
    * **Warning! Not allowed when node is in Gateway mode!**
    *
+   * @param options Options that affects the request behavior
    * @see [Bee docs - Pinning](https://docs.ethswarm.org/docs/access-the-swarm/pinning)
    */
   async getAllPins(options?: RequestOptions): Promise<Reference[]> {
@@ -520,6 +531,7 @@ export class Bee {
    * **Warning! Not allowed when node is in Gateway mode!**
    *
    * @param reference Bee data reference
+   * @param options Options that affects the request behavior
    * @throws TypeError if reference is in not correct format
    *
    * @see [Bee docs - Pinning](https://docs.ethswarm.org/docs/access-the-swarm/pinning)
@@ -535,6 +547,7 @@ export class Bee {
    * Instructs the Bee node to reupload a locally pinned data into the network.
    *
    * @param reference
+   * @param options Options that affects the request behavior
    * @throws BeeArgumentError if the reference is not locally pinned
    * @throws TypeError if reference is in not correct format
    */
@@ -573,6 +586,7 @@ export class Bee {
    * @param target Target message address prefix. Has a limit on length. Recommend to use `Utils.Pss.makeMaxTarget()` to get the most specific target that Bee node will accept.
    * @param data Message to be sent
    * @param recipient Recipient public key
+   * @param options Options that affects the request behavior
    * @throws TypeError if `data`, `batchId`, `target` or `recipient` are in invalid format
    *
    * @see [Bee docs - PSS](https://docs.ethswarm.org/docs/dapps-on-swarm/pss)
@@ -735,6 +749,7 @@ export class Bee {
    * @param type            The type of the feed, can be 'epoch' or 'sequence'
    * @param topic           Topic in hex or bytes
    * @param owner           Owner's ethereum address in hex or bytes
+   * @param options Options that affects the request behavior
    *
    * @see [Bee docs - Feeds](https://docs.ethswarm.org/docs/dapps-on-swarm/feeds)
    * @see [Bee API reference - `POST /feeds`](https://docs.ethswarm.org/api/#tag/Feed/paths/~1feeds~1{owner}~1{topic}/post)
@@ -762,6 +777,7 @@ export class Bee {
    * @param type    The type of the feed, can be 'epoch' or 'sequence'
    * @param topic   Topic in hex or bytes
    * @param owner   Owner's ethereum address in hex or bytes
+   * @param options Options that affects the request behavior
    *
    * @see [Bee docs - Feeds](https://docs.ethswarm.org/docs/dapps-on-swarm/feeds)
    */
@@ -786,6 +802,7 @@ export class Bee {
    * @param type    The type of the feed, can be 'epoch' or 'sequence'
    * @param topic   Topic in hex or bytes
    * @param signer  The signer's private key or a Signer instance that can sign data
+   * @param options Options that affects the request behavior
    *
    * @see [Bee docs - Feeds](https://docs.ethswarm.org/docs/dapps-on-swarm/feeds)
    */
@@ -904,7 +921,7 @@ export class Bee {
    * Returns an object for reading single owner chunks
    *
    * @param ownerAddress The ethereum address of the owner
-   *
+   * @param options Options that affects the request behavior
    * @see [Bee docs - Chunk Types](https://docs.ethswarm.org/docs/dapps-on-swarm/chunk-types#single-owner-chunks)
    */
   makeSOCReader(ownerAddress: EthAddress | Uint8Array | string, options?: RequestOptions): SOCReader {
@@ -920,7 +937,7 @@ export class Bee {
    * Returns an object for reading and writing single owner chunks
    *
    * @param signer The signer's private key or a Signer instance that can sign data
-   *
+   * @param options Options that affects the request behavior
    * @see [Bee docs - Chunk Types](https://docs.ethswarm.org/docs/dapps-on-swarm/chunk-types#single-owner-chunks)
    */
   makeSOCWriter(signer?: Signer | Uint8Array | string, options?: RequestOptions): SOCWriter {
@@ -945,7 +962,7 @@ export class Bee {
    *
    * @param amount Amount that represents the value per chunk, has to be greater or equal zero.
    * @param depth Logarithm of the number of chunks that can be stamped with the batch.
-   * @param options Options for creation of postage batch
+   * @param options Options for creation of postage batch and request options
    * @throws BeeArgumentError when negative amount or depth is specified
    * @throws TypeError if non-integer value is passed to amount or depth
    *
@@ -954,7 +971,7 @@ export class Bee {
    * @deprecated Use DebugBee for postage batch management
    */
   async createPostageBatch(amount: NumberString, depth: number, options?: PostageBatchOptions): Promise<BatchId> {
-    assertRequestOptions(options, 'PostageBatchOptions')
+    assertPostageBatchOptions(options)
     assertNonNegativeInteger(amount)
     assertNonNegativeInteger(depth)
 
@@ -966,14 +983,6 @@ export class Bee {
       throw new BeeArgumentError(`Depth has to be at most ${STAMPS_DEPTH_MAX}`, depth)
     }
 
-    if (options?.gasPrice) {
-      assertNonNegativeInteger(options.gasPrice)
-    }
-
-    if (options?.immutableFlag !== undefined) {
-      assertBoolean(options.immutableFlag)
-    }
-
     return stamps.createPostageBatch(this.getKy(options), amount, depth, options)
   }
 
@@ -983,12 +992,14 @@ export class Bee {
    * **Warning! Not allowed when node is in Gateway mode!**
    *
    * @param postageBatchId Batch ID
+   * @param options Options that affects the request behavior
    *
    * @see [Bee docs - Keep your data alive / Postage stamps](https://docs.ethswarm.org/docs/access-the-swarm/keep-your-data-alive)
    * @see [Bee API reference - `GET /stamps/${id}`](https://docs.ethswarm.org/api/#tag/Postage-Stamps/paths/~1stamps~1{id}/get)
    * @deprecated Use DebugBee for postage batch management
    */
   async getPostageBatch(postageBatchId: BatchId | string, options?: RequestOptions): Promise<PostageBatch> {
+    assertRequestOptions(options, 'PostageBatchOptions')
     assertBatchId(postageBatchId)
 
     return stamps.getPostageBatch(this.getKy(options), postageBatchId)
@@ -999,29 +1010,38 @@ export class Bee {
    *
    * **Warning! Not allowed when node is in Gateway mode!**
    *
+   * @param options Options that affects the request behavior
    * @see [Bee docs - Keep your data alive / Postage stamps](https://docs.ethswarm.org/docs/access-the-swarm/keep-your-data-alive)
    * @see [Bee API reference - `GET /stamps`](https://docs.ethswarm.org/api/#tag/Postage-Stamps/paths/~1stamps/get)
    * @deprecated Use DebugBee for postage batch management
    */
   async getAllPostageBatch(options?: RequestOptions): Promise<PostageBatch[]> {
+    assertRequestOptions(options, 'PostageBatchOptions')
+
     return stamps.getAllPostageBatches(this.getKy(options))
   }
 
   /**
    * Ping the Bee node to see if there is a live Bee node on the given URL.
    *
+   * @param options Options that affects the request behavior
    * @throws If connection was not successful throw error
    */
   async checkConnection(options?: RequestOptions): Promise<void> | never {
+    assertRequestOptions(options, 'PostageBatchOptions')
+
     return status.checkConnection(this.getKy(options))
   }
 
   /**
    * Ping the Bee node to see if there is a live Bee node on the given URL.
    *
+   * @param options Options that affects the request behavior
    * @returns true if successful, false on error
    */
   async isConnected(options?: RequestOptions): Promise<boolean> {
+    assertRequestOptions(options, 'PostageBatchOptions')
+
     try {
       await status.checkConnection(this.getKy(options))
     } catch (e) {

--- a/src/feed/json.ts
+++ b/src/feed/json.ts
@@ -1,4 +1,4 @@
-import { FeedWriter, FeedReader, AnyJson, BatchId, Reference } from '../types'
+import { FeedWriter, FeedReader, AnyJson, BatchId, Reference, RequestOptions } from '../types'
 import { Bee } from '../bee'
 
 function serializeJson(data: AnyJson): Uint8Array {
@@ -24,9 +24,10 @@ export async function setJsonData(
   writer: FeedWriter,
   postageBatchId: BatchId,
   data: AnyJson,
+  options?: RequestOptions,
 ): Promise<Reference> {
   const serializedData = serializeJson(data)
-  const { reference } = await bee.uploadData(postageBatchId, serializedData)
+  const { reference } = await bee.uploadData(postageBatchId, serializedData, options)
 
   return writer.upload(postageBatchId, reference)
 }

--- a/src/types/debug.ts
+++ b/src/types/debug.ts
@@ -1,4 +1,4 @@
-import { PublicKey, NumberString, Reference, TransactionHash } from './index'
+import { PublicKey, NumberString, Reference, TransactionHash, RequestOptions } from './index'
 import { HexEthAddress } from '../utils/eth'
 
 /**
@@ -86,7 +86,7 @@ export interface ChequebookBalanceResponse {
   availableBalance: NumberString
 }
 
-export interface CashoutOptions {
+export interface CashoutOptions extends RequestOptions {
   /**
    * Gas price for the cashout transaction in WEI
    */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,7 +72,27 @@ export type BatchId = HexString<typeof BATCH_ID_HEX_LENGTH>
  */
 export type AddressPrefix = HexString
 
-export interface BeeOptions {
+export interface RequestOptions {
+  /**
+   * Timeout of requests in milliseconds
+   */
+  timeout?: number
+
+  /**
+   * Configure backoff mechanism for requests retries.
+   * Specifies how many retries will be performed before failing a request.
+   * Retries are performed for GET, PUT, HEAD, DELETE, OPTIONS and TRACE requests.
+   * Default is 2.
+   */
+  retry?: number
+
+  /**
+   * User defined Fetch compatible function
+   */
+  fetch?: Fetch
+}
+
+export interface BeeOptions extends RequestOptions {
   /**
    * Signer object or private key of the Signer in form of either hex string or Uint8Array that will be default signer for the instance.
    */
@@ -115,7 +135,7 @@ export interface UploadResult {
   tagUid?: number
 }
 
-export interface UploadOptions {
+export interface UploadOptions extends RequestOptions {
   /**
    * Will pin the data locally in the Bee node as well.
    *
@@ -222,7 +242,7 @@ export interface Tag {
   startedAt: string
 }
 
-export interface AllTagsOptions {
+export interface AllTagsOptions extends RequestOptions {
   limit?: number
   offset?: number
 }
@@ -344,7 +364,7 @@ export interface FeedReader {
   download(options?: FeedUpdateOptions): Promise<FetchFeedUpdateResponse>
 }
 
-export interface JsonFeedOptions {
+export interface JsonFeedOptions extends RequestOptions {
   /**
    * Valid only for `get` action, where either this `address` or `signer` has
    * to be specified.
@@ -464,7 +484,7 @@ export interface TransactionInfo {
 /**
  * Options for creation of postage batch
  */
-export interface PostageBatchOptions {
+export interface PostageBatchOptions extends RequestOptions {
   /**
    * Sets label for the postage batch
    */
@@ -542,3 +562,5 @@ interface JsonMap {
   [key: string]: AnyJson
 }
 type JsonArray = Array<AnyJson>
+
+type Fetch = (input: RequestInfo, init?: RequestInit) => Promise<Response>

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -22,6 +22,8 @@ import {
   UploadOptions,
   TransactionHash,
   RequestOptions,
+  PostageBatchOptions,
+  CashoutOptions,
 } from '../types'
 import { BeeArgumentError } from './error'
 import { isFile } from './file'
@@ -58,6 +60,13 @@ export function isObject(value: unknown): value is Record<string, unknown> {
 // eslint-disable-next-line @typescript-eslint/ban-types
 export function isStrictlyObject(value: unknown): value is object {
   return isObject(value) && !Array.isArray(value)
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function assertStrictlyObject(value: unknown, name = 'value'): asserts value is object {
+  if (!isStrictlyObject(value)) {
+    throw new TypeError(`${name} has to be an object that is not null nor array!`)
+  }
 }
 
 export function assertBoolean(value: unknown, name = 'value'): asserts value is boolean {
@@ -245,6 +254,44 @@ export function assertPssMessageHandler(value: unknown): asserts value is PssMes
 
 export function assertPublicKey(value: unknown): asserts value is PublicKey {
   assertHexString(value, PUBKEY_HEX_LENGTH, 'PublicKey')
+}
+
+export function assertPostageBatchOptions(value: unknown): asserts value is PostageBatchOptions {
+  if (value === undefined) {
+    return
+  }
+
+  assertStrictlyObject(value)
+
+  const options = value as PostageBatchOptions
+  assertRequestOptions(options, 'PostageBatchOptions')
+
+  if (options?.gasPrice) {
+    assertNonNegativeInteger(options.gasPrice)
+  }
+
+  if (options?.immutableFlag !== undefined) {
+    assertBoolean(options.immutableFlag)
+  }
+}
+
+export function assertCashoutOptions(value: unknown): asserts value is CashoutOptions {
+  if (value === undefined) {
+    return
+  }
+
+  assertStrictlyObject(value)
+
+  const options = value as CashoutOptions
+  assertRequestOptions(options, 'PostageBatchOptions')
+
+  if (options?.gasLimit) {
+    assertNonNegativeInteger(options.gasLimit)
+  }
+
+  if (options?.gasPrice) {
+    assertNonNegativeInteger(options.gasPrice)
+  }
 }
 
 /**

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -21,6 +21,7 @@ import {
   PSS_TARGET_HEX_LENGTH_MAX,
   UploadOptions,
   TransactionHash,
+  RequestOptions,
 } from '../types'
 import { BeeArgumentError } from './error'
 import { isFile } from './file'
@@ -59,16 +60,16 @@ export function isStrictlyObject(value: unknown): value is object {
   return isObject(value) && !Array.isArray(value)
 }
 
-export function assertBoolean(value: unknown): asserts value is boolean {
-  if (value !== true && value !== false) throw new TypeError('value is not boolean')
+export function assertBoolean(value: unknown, name = 'value'): asserts value is boolean {
+  if (value !== true && value !== false) throw new TypeError(`${name} is not boolean`)
 }
 
-export function assertInteger(value: unknown): asserts value is number | NumberString {
-  if (!isInteger(value)) throw new TypeError('value is not integer')
+export function assertInteger(value: unknown, name = 'value'): asserts value is number | NumberString {
+  if (!isInteger(value)) throw new TypeError(`${name} is not integer`)
 }
 
 export function assertNonNegativeInteger(value: unknown, name = 'Value'): asserts value is number | NumberString {
-  assertInteger(value)
+  assertInteger(value, name)
 
   if (Number(value) < 0) throw new BeeArgumentError(`${name} has to be bigger or equal to zero`, value)
 }
@@ -89,10 +90,36 @@ export function assertBatchId(value: unknown): asserts value is BatchId {
   assertHexString(value, BATCH_ID_HEX_LENGTH, 'BatchId')
 }
 
+export function assertRequestOptions(value: unknown, name = 'RequestOptions'): asserts value is RequestOptions {
+  if (value === undefined) {
+    return
+  }
+
+  if (!isStrictlyObject(value)) {
+    throw new TypeError(`${name} has to be an object!`)
+  }
+
+  const options = value as RequestOptions
+
+  if (options.retry) {
+    assertNonNegativeInteger(options.retry, `${name}.retry`)
+  }
+
+  if (options.timeout) {
+    assertNonNegativeInteger(options.timeout, `${name}.timeout`)
+  }
+
+  if (options.fetch && typeof options.fetch !== 'function') {
+    throw new TypeError(`${name}.fetch has to be a function or undefined!`)
+  }
+}
+
 export function assertUploadOptions(value: unknown, name = 'UploadOptions'): asserts value is UploadOptions {
   if (!isStrictlyObject(value)) {
     throw new TypeError(`${name} has to be an object!`)
   }
+
+  assertRequestOptions(value, name)
 
   const options = value as UploadOptions
 
@@ -251,24 +278,26 @@ export function assertAllTagsOptions(entry: unknown): asserts entry is AllTagsOp
     throw new TypeError('options has to be an object or undefined!')
   }
 
+  assertRequestOptions(entry, 'AllTagsOptions')
+
   const options = entry as AllTagsOptions
 
   if (options?.limit !== undefined) {
     if (typeof options.limit !== 'number') {
-      throw new TypeError('options.limit has to be a number or undefined!')
+      throw new TypeError('AllTagsOptions.limit has to be a number or undefined!')
     }
 
     if (options.limit < TAGS_LIMIT_MIN) {
-      throw new BeeArgumentError(`options.limit has to be at least ${TAGS_LIMIT_MIN}`, options.limit)
+      throw new BeeArgumentError(`AllTagsOptions.limit has to be at least ${TAGS_LIMIT_MIN}`, options.limit)
     }
 
     if (options.limit > TAGS_LIMIT_MAX) {
-      throw new BeeArgumentError(`options.limit has to be at most ${TAGS_LIMIT_MAX}`, options.limit)
+      throw new BeeArgumentError(`AllTagsOptions.limit has to be at most ${TAGS_LIMIT_MAX}`, options.limit)
     }
   }
 
   if (options?.offset !== undefined) {
-    assertNonNegativeInteger(options.offset, 'options.offset')
+    assertNonNegativeInteger(options.offset, 'AllTagsOptions.offset')
   }
 }
 

--- a/test/unit/assertions.ts
+++ b/test/unit/assertions.ts
@@ -1,6 +1,7 @@
 /* eslint-disable */
 import { BeeArgumentError } from '../../src'
 import { makeBytes } from '../../src/utils/bytes'
+import { assertCashoutOptions } from '../../src/utils/type'
 
 export function testBatchIdAssertion(executor: (input: unknown) => void): void {
   it('should throw exception for bad BatchId', async () => {
@@ -99,6 +100,48 @@ export function testRequestOptionsAssertions(executor: (input: unknown) => void)
     await expect(() => executor({ fetch: [] })).rejects.toThrow(TypeError)
     await expect(() => executor({ fetch: -1 })).rejects.toThrow(TypeError)
     await expect(() => executor({ fetch: 1 })).rejects.toThrow(TypeError)
+  })
+}
+
+export function testPostageBatchOptionsAssertions(executor: (input: unknown) => void): void {
+  it('should throw exception for bad PostageBatch', async () => {
+    await expect(() => executor(1)).rejects.toThrow(TypeError)
+    await expect(() => executor(true)).rejects.toThrow(TypeError)
+    await expect(() => executor([])).rejects.toThrow(TypeError)
+    await expect(() => executor('string')).rejects.toThrow(TypeError)
+
+    await expect(() => executor({ gasPrice: 'plur' })).rejects.toThrow(TypeError)
+    await expect(() => executor({ gasPrice: true })).rejects.toThrow(TypeError)
+    await expect(() => executor({ gasPrice: {} })).rejects.toThrow(TypeError)
+    await expect(() => executor({ gasPrice: [] })).rejects.toThrow(TypeError)
+    await expect(() => executor({ gasPrice: -1 })).rejects.toThrow(BeeArgumentError)
+
+    await expect(() => executor({ immutableFlag: 'plur' })).rejects.toThrow(TypeError)
+    await expect(() => executor({ immutableFlag: 1 })).rejects.toThrow(TypeError)
+    await expect(() => executor({ immutableFlag: null })).rejects.toThrow(TypeError)
+    await expect(() => executor({ immutableFlag: {} })).rejects.toThrow(TypeError)
+    await expect(() => executor({ immutableFlag: [] })).rejects.toThrow(TypeError)
+  })
+}
+
+export function testCashoutOptionsAssertions(executor: (input: unknown) => void): void {
+  it('should throw exception for bad CashoutOptions', async () => {
+    await expect(() => executor(1)).rejects.toThrow(TypeError)
+    await expect(() => executor(true)).rejects.toThrow(TypeError)
+    await expect(() => executor([])).rejects.toThrow(TypeError)
+    await expect(() => executor('string')).rejects.toThrow(TypeError)
+
+    await expect(() => executor({ gasPrice: 'plur' })).rejects.toThrow(TypeError)
+    await expect(() => executor({ gasPrice: true })).rejects.toThrow(TypeError)
+    await expect(() => executor({ gasPrice: {} })).rejects.toThrow(TypeError)
+    await expect(() => executor({ gasPrice: [] })).rejects.toThrow(TypeError)
+    await expect(() => executor({ gasPrice: -1 })).rejects.toThrow(BeeArgumentError)
+
+    await expect(() => executor({ gasLimit: 'plur' })).rejects.toThrow(TypeError)
+    await expect(() => executor({ gasLimit: true })).rejects.toThrow(TypeError)
+    await expect(() => executor({ gasLimit: {} })).rejects.toThrow(TypeError)
+    await expect(() => executor({ gasLimit: [] })).rejects.toThrow(TypeError)
+    await expect(() => executor({ gasLimit: -1 })).rejects.toThrow(BeeArgumentError)
   })
 }
 

--- a/test/unit/assertions.ts
+++ b/test/unit/assertions.ts
@@ -3,7 +3,7 @@ import { BeeArgumentError, BeeOptions } from '../../src'
 import { makeBytes } from '../../src/utils/bytes'
 import { assertCashoutOptions } from '../../src/utils/type'
 
-export function testBatchIdAssertion (executor: (input: unknown) => void): void {
+export function testBatchIdAssertion(executor: (input: unknown) => void): void {
   it('should throw exception for bad BatchId', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -15,17 +15,17 @@ export function testBatchIdAssertion (executor: (input: unknown) => void): void 
 
     // Not an valid hexstring (ZZZ)
     await expect(() => executor('ZZZfb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError
+      TypeError,
     )
 
     // Prefixed hexstring is not accepted
     await expect(() => executor('0x634fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError
+      TypeError,
     )
   })
 }
 
-export function testDataAssertions (executor: (input: unknown) => void): void {
+export function testDataAssertions(executor: (input: unknown) => void): void {
   it('should throw exception for bad Data', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -36,7 +36,7 @@ export function testDataAssertions (executor: (input: unknown) => void): void {
   })
 }
 
-export function testFileDataAssertions (executor: (input: unknown) => void): void {
+export function testFileDataAssertions(executor: (input: unknown) => void): void {
   it('should throw exception for bad FileData', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -50,7 +50,7 @@ export function testFileDataAssertions (executor: (input: unknown) => void): voi
   })
 }
 
-export function testUploadOptionsAssertions (executor: (input: unknown) => void): void {
+export function testUploadOptionsAssertions(executor: (input: unknown) => void): void {
   it('should throw exception for bad UploadOptions', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -75,7 +75,10 @@ export function testUploadOptionsAssertions (executor: (input: unknown) => void)
   })
 }
 
-export function testRequestOptionsAssertions (executor: (input: unknown, beeOptions?: BeeOptions) => void, testFetch = true): void {
+export function testRequestOptionsAssertions(
+  executor: (input: unknown, beeOptions?: BeeOptions) => void,
+  testFetch = true,
+): void {
   it('should throw exception for bad RequestOptions', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -116,14 +119,16 @@ export function testRequestOptionsAssertions (executor: (input: unknown, beeOpti
       const callMessage = 'call error'
       const callError = { message: callMessage }
       callFetch.mockRejectedValue(callError)
-      await expect(() => executor({ fetch: callFetch }, { retry: 0, fetch: instanceFetch })).rejects.toThrow(callMessage)
+      await expect(() => executor({ fetch: callFetch }, { retry: 0, fetch: instanceFetch })).rejects.toThrow(
+        callMessage,
+      )
       expect(instanceFetch.mock.calls.length).toEqual(1) // The count did not change from last call
       expect(callFetch.mock.calls.length).toEqual(1)
     })
   }
 }
 
-export function testPostageBatchOptionsAssertions (executor: (input: unknown) => void): void {
+export function testPostageBatchOptionsAssertions(executor: (input: unknown) => void): void {
   it('should throw exception for bad PostageBatch', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -144,7 +149,7 @@ export function testPostageBatchOptionsAssertions (executor: (input: unknown) =>
   })
 }
 
-export function testCashoutOptionsAssertions (executor: (input: unknown) => void): void {
+export function testCashoutOptionsAssertions(executor: (input: unknown) => void): void {
   it('should throw exception for bad CashoutOptions', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -165,7 +170,7 @@ export function testCashoutOptionsAssertions (executor: (input: unknown) => void
   })
 }
 
-export function testFileUploadOptionsAssertions (executor: (input: unknown) => void): void {
+export function testFileUploadOptionsAssertions(executor: (input: unknown) => void): void {
   it('should throw exception for bad FileUploadOptions', async () => {
     await expect(() => executor({ contentType: true })).rejects.toThrow(TypeError)
     await expect(() => executor({ contentType: 1 })).rejects.toThrow(TypeError)
@@ -180,7 +185,7 @@ export function testFileUploadOptionsAssertions (executor: (input: unknown) => v
   })
 }
 
-export function testCollectionUploadOptionsAssertions (executor: (input: unknown) => void): void {
+export function testCollectionUploadOptionsAssertions(executor: (input: unknown) => void): void {
   it('should throw exception for bad CollectionUploadOptions', async () => {
     await expect(() => executor({ indexDocument: true })).rejects.toThrow(TypeError)
     await expect(() => executor({ indexDocument: 1 })).rejects.toThrow(TypeError)
@@ -194,7 +199,7 @@ export function testCollectionUploadOptionsAssertions (executor: (input: unknown
   })
 }
 
-export function testReferenceAssertions (executor: (input: unknown) => void): void {
+export function testReferenceAssertions(executor: (input: unknown) => void): void {
   it('should throw exception for bad Reference', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -206,22 +211,22 @@ export function testReferenceAssertions (executor: (input: unknown) => void): vo
 
     // Not an valid hexstring (ZZZ)
     await expect(() => executor('ZZZfb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError
+      TypeError,
     )
 
     // Prefixed hexstring is not accepted
     await expect(() => executor('0x634fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError
+      TypeError,
     )
 
     // Length mismatch
     await expect(() => executor('4fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError
+      TypeError,
     )
   })
 }
 
-export function testAddressPrefixAssertions (executor: (input: unknown) => void): void {
+export function testAddressPrefixAssertions(executor: (input: unknown) => void): void {
   it('should throw exception for bad AddressPrefix', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -242,7 +247,7 @@ export function testAddressPrefixAssertions (executor: (input: unknown) => void)
   })
 }
 
-export function testPublicKeyAssertions (executor: (input: unknown) => void): void {
+export function testPublicKeyAssertions(executor: (input: unknown) => void): void {
   it('should throw exception for bad PublicKey', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -251,22 +256,22 @@ export function testPublicKeyAssertions (executor: (input: unknown) => void): vo
 
     // Not an valid hexstring (ZZZ)
     await expect(() => executor('ZZZfb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError
+      TypeError,
     )
 
     // Prefixed hexstring is not accepted
     await expect(() => executor('0x634fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError
+      TypeError,
     )
 
     // Length mismatch
     await expect(() => executor('4fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError
+      TypeError,
     )
   })
 }
 
-export function testPssMessageHandlerAssertions (executor: (input: unknown) => void): void {
+export function testPssMessageHandlerAssertions(executor: (input: unknown) => void): void {
   it('should throw exception for bad PssMessageHandler', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -277,48 +282,48 @@ export function testPssMessageHandlerAssertions (executor: (input: unknown) => v
     await expect(() => executor('')).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onMessage () {} })
+      return executor({ onMessage() {} })
     }).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onMessage () {}, onError: '' })
+      return executor({ onMessage() {}, onError: '' })
     }).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onMessage () {}, onError: [] })
+      return executor({ onMessage() {}, onError: [] })
     }).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onMessage () {}, onError: {} })
+      return executor({ onMessage() {}, onError: {} })
     }).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onMessage () {}, onError: true })
+      return executor({ onMessage() {}, onError: true })
     }).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onError () {}, onMessage: true })
+      return executor({ onError() {}, onMessage: true })
     }).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onError () {}, onMessage: {} })
+      return executor({ onError() {}, onMessage: {} })
     }).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onError () {}, onMessage: [] })
+      return executor({ onError() {}, onMessage: [] })
     }).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onError () {}, onMessage: '' })
+      return executor({ onError() {}, onMessage: '' })
     }).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onError () {}, onMessage: 1 })
+      return executor({ onError() {}, onMessage: 1 })
     }).rejects.toThrow(TypeError)
   })
 }
 
-export function testTopicAssertions (executor: (input: unknown) => void): void {
+export function testTopicAssertions(executor: (input: unknown) => void): void {
   it('should throw exception for bad Topic', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -329,7 +334,7 @@ export function testTopicAssertions (executor: (input: unknown) => void): void {
   })
 }
 
-export function testFeedTopicAssertions (executor: (input: unknown) => void): void {
+export function testFeedTopicAssertions(executor: (input: unknown) => void): void {
   it('should throw exception for bad Topic', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -340,17 +345,17 @@ export function testFeedTopicAssertions (executor: (input: unknown) => void): vo
 
     // Not an valid hexstring (ZZZ)
     await expect(() => executor('ZZZfb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError
+      TypeError,
     )
 
     // Length mismatch
     await expect(() => executor('4fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError
+      TypeError,
     )
   })
 }
 
-export function testEthAddressAssertions (executor: (input: unknown) => void): void {
+export function testEthAddressAssertions(executor: (input: unknown) => void): void {
   it('should throw exception for bad EthAddress', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -361,12 +366,12 @@ export function testEthAddressAssertions (executor: (input: unknown) => void): v
 
     // Not an valid hexstring (ZZZ)
     await expect(() => executor('ZZZfb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError
+      TypeError,
     )
 
     // Length mismatch
     await expect(() => executor('4fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError
+      TypeError,
     )
 
     // Bytes length mismatch
@@ -374,7 +379,7 @@ export function testEthAddressAssertions (executor: (input: unknown) => void): v
   })
 }
 
-export function testMakeSignerAssertions (executor: (input: unknown) => void, optionals = true): void {
+export function testMakeSignerAssertions(executor: (input: unknown) => void, optionals = true): void {
   it('should throw exception for bad Signer', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -388,12 +393,12 @@ export function testMakeSignerAssertions (executor: (input: unknown) => void, op
 
     // Not an valid hexstring (ZZZ)
     await expect(() => executor('ZZZfb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError
+      TypeError,
     )
 
     // Hex Length mismatch
     await expect(() => executor('4fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError
+      TypeError,
     )
 
     // Bytes Length mismatch
@@ -413,7 +418,7 @@ export function testMakeSignerAssertions (executor: (input: unknown) => void, op
   })
 }
 
-export function testFeedTypeAssertions (executor: (input: unknown) => void, optionals = true): void {
+export function testFeedTypeAssertions(executor: (input: unknown) => void, optionals = true): void {
   it('should throw exception for bad FeedType', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -429,7 +434,7 @@ export function testFeedTypeAssertions (executor: (input: unknown) => void, opti
   })
 }
 
-export function testAddressAssertions (executor: (input: unknown) => void, optionals = true): void {
+export function testAddressAssertions(executor: (input: unknown) => void, optionals = true): void {
   it('should throw exception for bad Address', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -439,12 +444,12 @@ export function testAddressAssertions (executor: (input: unknown) => void, optio
 
     // Not an valid hexstring (ZZZ)
     await expect(() => executor('ZZZfb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError
+      TypeError,
     )
 
     // Hex Length mismatch
     await expect(() => executor('4fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError
+      TypeError,
     )
 
     if (optionals) {

--- a/test/unit/assertions.ts
+++ b/test/unit/assertions.ts
@@ -74,6 +74,34 @@ export function testUploadOptionsAssertions(executor: (input: unknown) => void):
   })
 }
 
+export function testRequestOptionsAssertions(executor: (input: unknown) => void): void {
+  it('should throw exception for bad RequestOptions', async () => {
+    await expect(() => executor(1)).rejects.toThrow(TypeError)
+    await expect(() => executor(true)).rejects.toThrow(TypeError)
+    await expect(() => executor([])).rejects.toThrow(TypeError)
+    await expect(() => executor('string')).rejects.toThrow(TypeError)
+
+    await expect(() => executor({ timeout: 'plur' })).rejects.toThrow(TypeError)
+    await expect(() => executor({ timeout: true })).rejects.toThrow(TypeError)
+    await expect(() => executor({ timeout: {} })).rejects.toThrow(TypeError)
+    await expect(() => executor({ timeout: [] })).rejects.toThrow(TypeError)
+    await expect(() => executor({ timeout: -1 })).rejects.toThrow(BeeArgumentError)
+
+    await expect(() => executor({ retry: 'plur' })).rejects.toThrow(TypeError)
+    await expect(() => executor({ retry: true })).rejects.toThrow(TypeError)
+    await expect(() => executor({ retry: {} })).rejects.toThrow(TypeError)
+    await expect(() => executor({ retry: [] })).rejects.toThrow(TypeError)
+    await expect(() => executor({ retry: -1 })).rejects.toThrow(BeeArgumentError)
+
+    await expect(() => executor({ fetch: 'plur' })).rejects.toThrow(TypeError)
+    await expect(() => executor({ fetch: true })).rejects.toThrow(TypeError)
+    await expect(() => executor({ fetch: {} })).rejects.toThrow(TypeError)
+    await expect(() => executor({ fetch: [] })).rejects.toThrow(TypeError)
+    await expect(() => executor({ fetch: -1 })).rejects.toThrow(TypeError)
+    await expect(() => executor({ fetch: 1 })).rejects.toThrow(TypeError)
+  })
+}
+
 export function testFileUploadOptionsAssertions(executor: (input: unknown) => void): void {
   it('should throw exception for bad FileUploadOptions', async () => {
     await expect(() => executor({ contentType: true })).rejects.toThrow(TypeError)

--- a/test/unit/assertions.ts
+++ b/test/unit/assertions.ts
@@ -119,7 +119,7 @@ export function testRequestOptionsAssertions (executor: (input: unknown, beeOpti
       await expect(() => executor({ fetch: callFetch }, { retry: 0, fetch: instanceFetch })).rejects.toThrow(callMessage)
       expect(instanceFetch.mock.calls.length).toEqual(1) // The count did not change from last call
       expect(callFetch.mock.calls.length).toEqual(1)
-    }, 1000000)
+    })
   }
 }
 

--- a/test/unit/assertions.ts
+++ b/test/unit/assertions.ts
@@ -1,7 +1,6 @@
 /* eslint-disable */
 import { BeeArgumentError, BeeOptions } from '../../src'
 import { makeBytes } from '../../src/utils/bytes'
-import { assertCashoutOptions } from '../../src/utils/type'
 
 export function testBatchIdAssertion(executor: (input: unknown) => void): void {
   it('should throw exception for bad BatchId', async () => {

--- a/test/unit/assertions.ts
+++ b/test/unit/assertions.ts
@@ -1,9 +1,9 @@
 /* eslint-disable */
-import { BeeArgumentError } from '../../src'
+import { BeeArgumentError, BeeOptions } from '../../src'
 import { makeBytes } from '../../src/utils/bytes'
 import { assertCashoutOptions } from '../../src/utils/type'
 
-export function testBatchIdAssertion(executor: (input: unknown) => void): void {
+export function testBatchIdAssertion (executor: (input: unknown) => void): void {
   it('should throw exception for bad BatchId', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -15,17 +15,17 @@ export function testBatchIdAssertion(executor: (input: unknown) => void): void {
 
     // Not an valid hexstring (ZZZ)
     await expect(() => executor('ZZZfb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError,
+      TypeError
     )
 
     // Prefixed hexstring is not accepted
     await expect(() => executor('0x634fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError,
+      TypeError
     )
   })
 }
 
-export function testDataAssertions(executor: (input: unknown) => void): void {
+export function testDataAssertions (executor: (input: unknown) => void): void {
   it('should throw exception for bad Data', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -36,7 +36,7 @@ export function testDataAssertions(executor: (input: unknown) => void): void {
   })
 }
 
-export function testFileDataAssertions(executor: (input: unknown) => void): void {
+export function testFileDataAssertions (executor: (input: unknown) => void): void {
   it('should throw exception for bad FileData', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -50,7 +50,7 @@ export function testFileDataAssertions(executor: (input: unknown) => void): void
   })
 }
 
-export function testUploadOptionsAssertions(executor: (input: unknown) => void): void {
+export function testUploadOptionsAssertions (executor: (input: unknown) => void): void {
   it('should throw exception for bad UploadOptions', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -75,11 +75,12 @@ export function testUploadOptionsAssertions(executor: (input: unknown) => void):
   })
 }
 
-export function testRequestOptionsAssertions(executor: (input: unknown) => void): void {
+export function testRequestOptionsAssertions (executor: (input: unknown, beeOptions?: BeeOptions) => void, testFetch = true): void {
   it('should throw exception for bad RequestOptions', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
     await expect(() => executor([])).rejects.toThrow(TypeError)
+    await expect(() => executor(() => {})).rejects.toThrow(TypeError)
     await expect(() => executor('string')).rejects.toThrow(TypeError)
 
     await expect(() => executor({ timeout: 'plur' })).rejects.toThrow(TypeError)
@@ -101,9 +102,28 @@ export function testRequestOptionsAssertions(executor: (input: unknown) => void)
     await expect(() => executor({ fetch: -1 })).rejects.toThrow(TypeError)
     await expect(() => executor({ fetch: 1 })).rejects.toThrow(TypeError)
   })
+
+  if (testFetch) {
+    it('should use per-call request options instead of instance request options', async () => {
+      const instanceFetch = jest.fn()
+      const instanceMessage = 'instance error'
+      const instanceError = { message: instanceMessage }
+      instanceFetch.mockRejectedValue(instanceError)
+      await expect(() => executor({}, { retry: 0, fetch: instanceFetch })).rejects.toThrow(instanceMessage)
+      expect(instanceFetch.mock.calls.length).toEqual(1)
+
+      const callFetch = jest.fn()
+      const callMessage = 'call error'
+      const callError = { message: callMessage }
+      callFetch.mockRejectedValue(callError)
+      await expect(() => executor({ fetch: callFetch }, { retry: 0, fetch: instanceFetch })).rejects.toThrow(callMessage)
+      expect(instanceFetch.mock.calls.length).toEqual(1) // The count did not change from last call
+      expect(callFetch.mock.calls.length).toEqual(1)
+    }, 1000000)
+  }
 }
 
-export function testPostageBatchOptionsAssertions(executor: (input: unknown) => void): void {
+export function testPostageBatchOptionsAssertions (executor: (input: unknown) => void): void {
   it('should throw exception for bad PostageBatch', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -124,7 +144,7 @@ export function testPostageBatchOptionsAssertions(executor: (input: unknown) => 
   })
 }
 
-export function testCashoutOptionsAssertions(executor: (input: unknown) => void): void {
+export function testCashoutOptionsAssertions (executor: (input: unknown) => void): void {
   it('should throw exception for bad CashoutOptions', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -145,7 +165,7 @@ export function testCashoutOptionsAssertions(executor: (input: unknown) => void)
   })
 }
 
-export function testFileUploadOptionsAssertions(executor: (input: unknown) => void): void {
+export function testFileUploadOptionsAssertions (executor: (input: unknown) => void): void {
   it('should throw exception for bad FileUploadOptions', async () => {
     await expect(() => executor({ contentType: true })).rejects.toThrow(TypeError)
     await expect(() => executor({ contentType: 1 })).rejects.toThrow(TypeError)
@@ -160,7 +180,7 @@ export function testFileUploadOptionsAssertions(executor: (input: unknown) => vo
   })
 }
 
-export function testCollectionUploadOptionsAssertions(executor: (input: unknown) => void): void {
+export function testCollectionUploadOptionsAssertions (executor: (input: unknown) => void): void {
   it('should throw exception for bad CollectionUploadOptions', async () => {
     await expect(() => executor({ indexDocument: true })).rejects.toThrow(TypeError)
     await expect(() => executor({ indexDocument: 1 })).rejects.toThrow(TypeError)
@@ -174,7 +194,7 @@ export function testCollectionUploadOptionsAssertions(executor: (input: unknown)
   })
 }
 
-export function testReferenceAssertions(executor: (input: unknown) => void): void {
+export function testReferenceAssertions (executor: (input: unknown) => void): void {
   it('should throw exception for bad Reference', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -186,22 +206,22 @@ export function testReferenceAssertions(executor: (input: unknown) => void): voi
 
     // Not an valid hexstring (ZZZ)
     await expect(() => executor('ZZZfb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError,
+      TypeError
     )
 
     // Prefixed hexstring is not accepted
     await expect(() => executor('0x634fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError,
+      TypeError
     )
 
     // Length mismatch
     await expect(() => executor('4fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError,
+      TypeError
     )
   })
 }
 
-export function testAddressPrefixAssertions(executor: (input: unknown) => void): void {
+export function testAddressPrefixAssertions (executor: (input: unknown) => void): void {
   it('should throw exception for bad AddressPrefix', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -222,7 +242,7 @@ export function testAddressPrefixAssertions(executor: (input: unknown) => void):
   })
 }
 
-export function testPublicKeyAssertions(executor: (input: unknown) => void): void {
+export function testPublicKeyAssertions (executor: (input: unknown) => void): void {
   it('should throw exception for bad PublicKey', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -231,22 +251,22 @@ export function testPublicKeyAssertions(executor: (input: unknown) => void): voi
 
     // Not an valid hexstring (ZZZ)
     await expect(() => executor('ZZZfb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError,
+      TypeError
     )
 
     // Prefixed hexstring is not accepted
     await expect(() => executor('0x634fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError,
+      TypeError
     )
 
     // Length mismatch
     await expect(() => executor('4fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError,
+      TypeError
     )
   })
 }
 
-export function testPssMessageHandlerAssertions(executor: (input: unknown) => void): void {
+export function testPssMessageHandlerAssertions (executor: (input: unknown) => void): void {
   it('should throw exception for bad PssMessageHandler', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -257,48 +277,48 @@ export function testPssMessageHandlerAssertions(executor: (input: unknown) => vo
     await expect(() => executor('')).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onMessage() {} })
+      return executor({ onMessage () {} })
     }).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onMessage() {}, onError: '' })
+      return executor({ onMessage () {}, onError: '' })
     }).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onMessage() {}, onError: [] })
+      return executor({ onMessage () {}, onError: [] })
     }).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onMessage() {}, onError: {} })
+      return executor({ onMessage () {}, onError: {} })
     }).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onMessage() {}, onError: true })
+      return executor({ onMessage () {}, onError: true })
     }).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onError() {}, onMessage: true })
+      return executor({ onError () {}, onMessage: true })
     }).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onError() {}, onMessage: {} })
+      return executor({ onError () {}, onMessage: {} })
     }).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onError() {}, onMessage: [] })
+      return executor({ onError () {}, onMessage: [] })
     }).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onError() {}, onMessage: '' })
+      return executor({ onError () {}, onMessage: '' })
     }).rejects.toThrow(TypeError)
 
     await expect(() => {
-      return executor({ onError() {}, onMessage: 1 })
+      return executor({ onError () {}, onMessage: 1 })
     }).rejects.toThrow(TypeError)
   })
 }
 
-export function testTopicAssertions(executor: (input: unknown) => void): void {
+export function testTopicAssertions (executor: (input: unknown) => void): void {
   it('should throw exception for bad Topic', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -309,7 +329,7 @@ export function testTopicAssertions(executor: (input: unknown) => void): void {
   })
 }
 
-export function testFeedTopicAssertions(executor: (input: unknown) => void): void {
+export function testFeedTopicAssertions (executor: (input: unknown) => void): void {
   it('should throw exception for bad Topic', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -320,17 +340,17 @@ export function testFeedTopicAssertions(executor: (input: unknown) => void): voi
 
     // Not an valid hexstring (ZZZ)
     await expect(() => executor('ZZZfb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError,
+      TypeError
     )
 
     // Length mismatch
     await expect(() => executor('4fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError,
+      TypeError
     )
   })
 }
 
-export function testEthAddressAssertions(executor: (input: unknown) => void): void {
+export function testEthAddressAssertions (executor: (input: unknown) => void): void {
   it('should throw exception for bad EthAddress', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -341,12 +361,12 @@ export function testEthAddressAssertions(executor: (input: unknown) => void): vo
 
     // Not an valid hexstring (ZZZ)
     await expect(() => executor('ZZZfb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError,
+      TypeError
     )
 
     // Length mismatch
     await expect(() => executor('4fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError,
+      TypeError
     )
 
     // Bytes length mismatch
@@ -354,7 +374,7 @@ export function testEthAddressAssertions(executor: (input: unknown) => void): vo
   })
 }
 
-export function testMakeSignerAssertions(executor: (input: unknown) => void, optionals = true): void {
+export function testMakeSignerAssertions (executor: (input: unknown) => void, optionals = true): void {
   it('should throw exception for bad Signer', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -368,12 +388,12 @@ export function testMakeSignerAssertions(executor: (input: unknown) => void, opt
 
     // Not an valid hexstring (ZZZ)
     await expect(() => executor('ZZZfb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError,
+      TypeError
     )
 
     // Hex Length mismatch
     await expect(() => executor('4fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError,
+      TypeError
     )
 
     // Bytes Length mismatch
@@ -393,7 +413,7 @@ export function testMakeSignerAssertions(executor: (input: unknown) => void, opt
   })
 }
 
-export function testFeedTypeAssertions(executor: (input: unknown) => void, optionals = true): void {
+export function testFeedTypeAssertions (executor: (input: unknown) => void, optionals = true): void {
   it('should throw exception for bad FeedType', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -409,7 +429,7 @@ export function testFeedTypeAssertions(executor: (input: unknown) => void, optio
   })
 }
 
-export function testAddressAssertions(executor: (input: unknown) => void, optionals = true): void {
+export function testAddressAssertions (executor: (input: unknown) => void, optionals = true): void {
   it('should throw exception for bad Address', async () => {
     await expect(() => executor(1)).rejects.toThrow(TypeError)
     await expect(() => executor(true)).rejects.toThrow(TypeError)
@@ -419,12 +439,12 @@ export function testAddressAssertions(executor: (input: unknown) => void, option
 
     // Not an valid hexstring (ZZZ)
     await expect(() => executor('ZZZfb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError,
+      TypeError
     )
 
     // Hex Length mismatch
     await expect(() => executor('4fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd')).rejects.toThrow(
-      TypeError,
+      TypeError
     )
 
     if (optionals) {

--- a/test/unit/bee-class.spec.ts
+++ b/test/unit/bee-class.spec.ts
@@ -17,7 +17,14 @@ import {
   RequestOptions,
   PostageBatchOptions,
 } from '../../src'
-import { testBatchId, testIdentity, testJsonHash, testJsonPayload, testJsonStringPayload } from '../utils'
+import {
+  testBatchId,
+  testChunkHash,
+  testIdentity,
+  testJsonHash,
+  testJsonPayload,
+  testJsonStringPayload,
+} from '../utils'
 import { makeTopicFromString } from '../../src/feed/topic'
 import {
   testAddressPrefixAssertions,
@@ -39,6 +46,7 @@ import {
   testPostageBatchOptionsAssertions,
 } from './assertions'
 import { FeedType } from '../../src/feed/type'
+import { isStrictlyObject } from '../../src/utils/type'
 
 const TOPIC = 'some=very%nice#topic'
 const HASHED_TOPIC = makeTopicFromString(TOPIC)
@@ -93,8 +101,8 @@ describe('Bee class', () => {
       return bee.uploadData(input as BatchId, '')
     })
 
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
       return bee.uploadData(testBatchId, '', input as RequestOptions)
     })
@@ -119,10 +127,10 @@ describe('Bee class', () => {
       return bee.downloadData(input as string)
     })
 
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
-      return bee.downloadData('', input as RequestOptions)
+      return bee.downloadData(testChunkHash, input as RequestOptions)
     })
   })
 
@@ -133,10 +141,10 @@ describe('Bee class', () => {
       return bee.downloadReadableData(input as string)
     })
 
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
-      return bee.downloadReadableData('', input as RequestOptions)
+      return bee.downloadReadableData(testChunkHash, input as RequestOptions)
     })
   })
 
@@ -147,8 +155,8 @@ describe('Bee class', () => {
       return bee.uploadFile(input as BatchId, '')
     })
 
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
       return bee.uploadFile(testBatchId, '', undefined, input as RequestOptions)
     })
@@ -179,10 +187,10 @@ describe('Bee class', () => {
       return bee.downloadFile(input as string)
     })
 
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
-      return bee.downloadFile('', '', input as RequestOptions)
+      return bee.downloadFile(testChunkHash, '', input as RequestOptions)
     })
   })
 
@@ -193,10 +201,10 @@ describe('Bee class', () => {
       return bee.downloadReadableFile(input as string)
     })
 
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
-      return bee.downloadReadableFile('', '', input as RequestOptions)
+      return bee.downloadReadableFile(testChunkHash, '', input as RequestOptions)
     })
   })
 
@@ -222,8 +230,8 @@ describe('Bee class', () => {
       return bee.uploadFiles(testBatchId, files, input as UploadOptions)
     })
 
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
       return bee.uploadFiles(testBatchId, files, input as RequestOptions)
     })
@@ -248,10 +256,10 @@ describe('Bee class', () => {
       return bee.uploadFilesFromDirectory(testBatchId, 'some path', input as CollectionUploadOptions)
     })
 
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
-      return bee.uploadFilesFromDirectory(testBatchId, 'some path', input as RequestOptions)
+      return bee.uploadFilesFromDirectory(testBatchId, './test/data', input as RequestOptions)
     })
 
     it('should throw exception for bad Dir', async () => {
@@ -274,8 +282,8 @@ describe('Bee class', () => {
   })
 
   describe('retrieveTag', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
       return bee.retrieveTag(0, input as RequestOptions)
     })
@@ -308,8 +316,8 @@ describe('Bee class', () => {
   })
 
   describe('deleteTag', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
       return bee.deleteTag(0, input as RequestOptions)
     })
@@ -342,8 +350,8 @@ describe('Bee class', () => {
   })
 
   describe('getAllTags', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
       return bee.getAllTags(input as RequestOptions)
     })
@@ -400,10 +408,10 @@ describe('Bee class', () => {
   })
 
   describe('pin', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
-      return bee.pin('', input as RequestOptions)
+      return bee.pin(testChunkHash, input as RequestOptions)
     })
 
     testReferenceAssertions(async (input: unknown) => {
@@ -414,10 +422,10 @@ describe('Bee class', () => {
   })
 
   describe('unpin', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
-      return bee.unpin('', input as RequestOptions)
+      return bee.unpin(testChunkHash, input as RequestOptions)
     })
     testReferenceAssertions(async (input: unknown) => {
       const bee = new Bee(MOCK_SERVER_URL)
@@ -427,10 +435,10 @@ describe('Bee class', () => {
   })
 
   describe('getPin', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
-      return bee.getPin('', input as RequestOptions)
+      return bee.getPin(testChunkHash, input as RequestOptions)
     })
     testReferenceAssertions(async (input: unknown) => {
       const bee = new Bee(MOCK_SERVER_URL)
@@ -440,10 +448,10 @@ describe('Bee class', () => {
   })
 
   describe('reuploadPinnedData', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
-      return bee.reuploadPinnedData('', input as RequestOptions)
+      return bee.reuploadPinnedData(testChunkHash, input as RequestOptions)
     })
 
     testReferenceAssertions(async (input: unknown) => {
@@ -454,10 +462,10 @@ describe('Bee class', () => {
   })
 
   describe('pssSend', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
-      return bee.pssSend('', 'topic', '123', 'data', '', input as RequestOptions)
+      return bee.pssSend(testBatchId, 'topic', '123', 'data', '', input as RequestOptions)
     })
 
     testBatchIdAssertion(async (input: unknown) => {
@@ -533,10 +541,10 @@ describe('Bee class', () => {
   })
 
   describe('createFeedManifest', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
-      return bee.createFeedManifest(testBatchId, 'epoch', '123', testIdentity.address, input as RequestOptions)
+      return bee.createFeedManifest(testBatchId, 'epoch', testChunkHash, testIdentity.address, input as RequestOptions)
     })
 
     testBatchIdAssertion(async (input: unknown) => {
@@ -565,11 +573,11 @@ describe('Bee class', () => {
   })
 
   describe('makeFeedReader', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
-      return bee.makeFeedReader('epoch', '123', testIdentity.address, input as RequestOptions)
-    })
+      return bee.makeFeedReader('epoch', testChunkHash, testIdentity.address, input as RequestOptions)
+    }, false)
 
     testFeedTypeAssertions(async (input: unknown) => {
       const bee = new Bee(MOCK_SERVER_URL)
@@ -591,11 +599,11 @@ describe('Bee class', () => {
   })
 
   describe('makeFeedWriter', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
-      return bee.makeFeedWriter('epoch', '123', testIdentity.address, input as RequestOptions)
-    })
+      return bee.makeFeedWriter('epoch', testChunkHash, testIdentity.address, input as RequestOptions)
+    }, false)
 
     testFeedTypeAssertions(async (input: unknown) => {
       const bee = new Bee(MOCK_SERVER_URL)
@@ -617,10 +625,21 @@ describe('Bee class', () => {
   })
 
   describe('setJsonFeed', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
-      return bee.setJsonFeed(testBatchId, 'epoch', '123', input as RequestOptions)
+      let opts
+
+      if (isStrictlyObject(input)) {
+        opts = {
+          signer: testIdentity.privateKey,
+          ...input,
+        }
+      } else {
+        opts = input
+      }
+
+      return bee.setJsonFeed(testBatchId, 'epoch', '123', opts as RequestOptions)
     })
 
     testBatchIdAssertion(async (input: unknown) => {
@@ -649,10 +668,21 @@ describe('Bee class', () => {
   })
 
   describe('getJsonFeed', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
-      return bee.getJsonFeed(TOPIC, input as RequestOptions)
+      let opts
+
+      if (isStrictlyObject(input)) {
+        opts = {
+          signer: testIdentity.privateKey,
+          ...input,
+        }
+      } else {
+        opts = input
+      }
+
+      return bee.getJsonFeed(TOPIC, opts as RequestOptions)
     })
 
     it('should fetch with specified address', async () => {
@@ -742,11 +772,11 @@ describe('Bee class', () => {
   })
 
   describe('makeSOCReader', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
-      return bee.makeSOCReader(testIdentity.address, input as RequestOptions)
-    })
+      return bee.makeSOCReader(testIdentity.privateKey, input as RequestOptions)
+    }, false)
 
     testEthAddressAssertions(async (input: unknown) => {
       const bee = new Bee(MOCK_SERVER_URL)
@@ -756,11 +786,11 @@ describe('Bee class', () => {
   })
 
   describe('makeSOCWriter', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new Bee(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new Bee(MOCK_SERVER_URL, beeOptions)
 
-      return bee.makeSOCWriter(testIdentity.address, input as RequestOptions)
-    })
+      return bee.makeSOCWriter(testIdentity.privateKey, input as RequestOptions)
+    }, false)
 
     testMakeSignerAssertions(async (input: unknown) => {
       const bee = new Bee(MOCK_SERVER_URL)

--- a/test/unit/bee-class.spec.ts
+++ b/test/unit/bee-class.spec.ts
@@ -15,6 +15,7 @@ import {
   ReferenceResponse,
   UploadOptions,
   RequestOptions,
+  PostageBatchOptions,
 } from '../../src'
 import { testBatchId, testIdentity, testJsonHash, testJsonPayload, testJsonStringPayload } from '../utils'
 import { makeTopicFromString } from '../../src/feed/topic'
@@ -35,6 +36,7 @@ import {
   testEthAddressAssertions,
   testMakeSignerAssertions,
   testRequestOptionsAssertions,
+  testPostageBatchOptionsAssertions,
 } from './assertions'
 import { FeedType } from '../../src/feed/type'
 
@@ -772,6 +774,12 @@ describe('Bee class', () => {
     const BATCH_RESPONSE = {
       batchID: BATCH_ID,
     }
+
+    testPostageBatchOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.createPostageBatch('10', 17, input as PostageBatchOptions)
+    })
 
     it('should not pass headers if no gas price is specified', async () => {
       createPostageBatchMock('10', '17').reply(201, BATCH_RESPONSE)

--- a/test/unit/bee-class.spec.ts
+++ b/test/unit/bee-class.spec.ts
@@ -14,6 +14,7 @@ import {
   PssMessageHandler,
   ReferenceResponse,
   UploadOptions,
+  RequestOptions,
 } from '../../src'
 import { testBatchId, testIdentity, testJsonHash, testJsonPayload, testJsonStringPayload } from '../utils'
 import { makeTopicFromString } from '../../src/feed/topic'
@@ -33,6 +34,7 @@ import {
   testFeedTopicAssertions,
   testEthAddressAssertions,
   testMakeSignerAssertions,
+  testRequestOptionsAssertions,
 } from './assertions'
 import { FeedType } from '../../src/feed/type'
 
@@ -89,6 +91,12 @@ describe('Bee class', () => {
       return bee.uploadData(input as BatchId, '')
     })
 
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.uploadData(testBatchId, '', input as RequestOptions)
+    })
+
     testDataAssertions(async (input: unknown) => {
       const bee = new Bee(MOCK_SERVER_URL)
 
@@ -108,6 +116,12 @@ describe('Bee class', () => {
 
       return bee.downloadData(input as string)
     })
+
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.downloadData('', input as RequestOptions)
+    })
   })
 
   describe('downloadReadableData', () => {
@@ -116,6 +130,12 @@ describe('Bee class', () => {
 
       return bee.downloadReadableData(input as string)
     })
+
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.downloadReadableData('', input as RequestOptions)
+    })
   })
 
   describe('uploadFile', () => {
@@ -123,6 +143,12 @@ describe('Bee class', () => {
       const bee = new Bee(MOCK_SERVER_URL)
 
       return bee.uploadFile(input as BatchId, '')
+    })
+
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.uploadFile(testBatchId, '', undefined, input as RequestOptions)
     })
 
     testFileDataAssertions(async (input: unknown) => {
@@ -150,6 +176,12 @@ describe('Bee class', () => {
 
       return bee.downloadFile(input as string)
     })
+
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.downloadFile('', '', input as RequestOptions)
+    })
   })
 
   describe('downloadReadableFile', () => {
@@ -157,6 +189,12 @@ describe('Bee class', () => {
       const bee = new Bee(MOCK_SERVER_URL)
 
       return bee.downloadReadableFile(input as string)
+    })
+
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.downloadReadableFile('', '', input as RequestOptions)
     })
   })
 
@@ -181,6 +219,12 @@ describe('Bee class', () => {
 
       return bee.uploadFiles(testBatchId, files, input as UploadOptions)
     })
+
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.uploadFiles(testBatchId, files, input as RequestOptions)
+    })
   })
 
   describe('uploadFilesFromDirectory', () => {
@@ -200,6 +244,12 @@ describe('Bee class', () => {
       const bee = new Bee(MOCK_SERVER_URL)
 
       return bee.uploadFilesFromDirectory(testBatchId, 'some path', input as CollectionUploadOptions)
+    })
+
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.uploadFilesFromDirectory(testBatchId, 'some path', input as RequestOptions)
     })
 
     it('should throw exception for bad Dir', async () => {
@@ -222,6 +272,12 @@ describe('Bee class', () => {
   })
 
   describe('retrieveTag', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.retrieveTag(0, input as RequestOptions)
+    })
+
     it('should throw exception for bad Tag', async () => {
       const bee = new Bee(MOCK_SERVER_URL)
 
@@ -250,6 +306,12 @@ describe('Bee class', () => {
   })
 
   describe('deleteTag', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.deleteTag(0, input as RequestOptions)
+    })
+
     it('should throw exception for bad Tag', async () => {
       const bee = new Bee(MOCK_SERVER_URL)
 
@@ -278,6 +340,12 @@ describe('Bee class', () => {
   })
 
   describe('getAllTags', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.getAllTags(input as RequestOptions)
+    })
+
     it('should throw exception for bad options', async () => {
       const bee = new Bee(MOCK_SERVER_URL)
 
@@ -330,6 +398,12 @@ describe('Bee class', () => {
   })
 
   describe('pin', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.pin('', input as RequestOptions)
+    })
+
     testReferenceAssertions(async (input: unknown) => {
       const bee = new Bee(MOCK_SERVER_URL)
 
@@ -338,6 +412,11 @@ describe('Bee class', () => {
   })
 
   describe('unpin', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.unpin('', input as RequestOptions)
+    })
     testReferenceAssertions(async (input: unknown) => {
       const bee = new Bee(MOCK_SERVER_URL)
 
@@ -346,6 +425,11 @@ describe('Bee class', () => {
   })
 
   describe('getPin', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.getPin('', input as RequestOptions)
+    })
     testReferenceAssertions(async (input: unknown) => {
       const bee = new Bee(MOCK_SERVER_URL)
 
@@ -354,6 +438,12 @@ describe('Bee class', () => {
   })
 
   describe('reuploadPinnedData', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.reuploadPinnedData('', input as RequestOptions)
+    })
+
     testReferenceAssertions(async (input: unknown) => {
       const bee = new Bee(MOCK_SERVER_URL)
 
@@ -362,6 +452,12 @@ describe('Bee class', () => {
   })
 
   describe('pssSend', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.pssSend('', 'topic', '123', 'data', '', input as RequestOptions)
+    })
+
     testBatchIdAssertion(async (input: unknown) => {
       const bee = new Bee(MOCK_SERVER_URL)
 
@@ -435,6 +531,12 @@ describe('Bee class', () => {
   })
 
   describe('createFeedManifest', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.createFeedManifest(testBatchId, 'epoch', '123', testIdentity.address, input as RequestOptions)
+    })
+
     testBatchIdAssertion(async (input: unknown) => {
       const bee = new Bee(MOCK_SERVER_URL)
 
@@ -461,6 +563,12 @@ describe('Bee class', () => {
   })
 
   describe('makeFeedReader', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.makeFeedReader('epoch', '123', testIdentity.address, input as RequestOptions)
+    })
+
     testFeedTypeAssertions(async (input: unknown) => {
       const bee = new Bee(MOCK_SERVER_URL)
 
@@ -481,6 +589,12 @@ describe('Bee class', () => {
   })
 
   describe('makeFeedWriter', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.makeFeedWriter('epoch', '123', testIdentity.address, input as RequestOptions)
+    })
+
     testFeedTypeAssertions(async (input: unknown) => {
       const bee = new Bee(MOCK_SERVER_URL)
 
@@ -501,6 +615,12 @@ describe('Bee class', () => {
   })
 
   describe('setJsonFeed', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.setJsonFeed(testBatchId, 'epoch', '123', input as RequestOptions)
+    })
+
     testBatchIdAssertion(async (input: unknown) => {
       const bee = new Bee(MOCK_SERVER_URL)
 
@@ -527,6 +647,12 @@ describe('Bee class', () => {
   })
 
   describe('getJsonFeed', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.getJsonFeed(TOPIC, input as RequestOptions)
+    })
+
     it('should fetch with specified address', async () => {
       downloadDataMock(testJsonHash).reply(200, testJsonStringPayload)
       fetchFeedUpdateMock(testIdentity.address, HASHED_TOPIC).reply(200, {
@@ -614,6 +740,12 @@ describe('Bee class', () => {
   })
 
   describe('makeSOCReader', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.makeSOCReader(testIdentity.address, input as RequestOptions)
+    })
+
     testEthAddressAssertions(async (input: unknown) => {
       const bee = new Bee(MOCK_SERVER_URL)
 
@@ -622,6 +754,12 @@ describe('Bee class', () => {
   })
 
   describe('makeSOCWriter', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new Bee(MOCK_SERVER_URL)
+
+      return bee.makeSOCWriter(testIdentity.address, input as RequestOptions)
+    })
+
     testMakeSignerAssertions(async (input: unknown) => {
       const bee = new Bee(MOCK_SERVER_URL)
 

--- a/test/unit/bee-debug-class.spec.ts
+++ b/test/unit/bee-debug-class.spec.ts
@@ -6,9 +6,15 @@ import {
   MOCK_SERVER_URL,
   withdrawTokensMock,
 } from './nock'
-import { BatchId, BeeArgumentError, BeeDebug, RequestOptions } from '../../src'
+import { BatchId, BeeArgumentError, BeeDebug, CashoutOptions, PostageBatchOptions, RequestOptions } from '../../src'
 import { testAddress, testBatchId } from '../utils'
-import { testAddressAssertions, testBatchIdAssertion, testRequestOptionsAssertions } from './assertions'
+import {
+  testAddressAssertions,
+  testBatchIdAssertion,
+  testCashoutOptionsAssertions,
+  testPostageBatchOptionsAssertions,
+  testRequestOptionsAssertions,
+} from './assertions'
 
 const TRANSACTION_HASH = '36b7efd913ca4cf880b8eeac5093fa27b0825906c600685b6abdd6566e6cfe8f'
 const CASHOUT_RESPONSE = {
@@ -157,6 +163,12 @@ describe('BeeDebug class', () => {
       return bee.cashoutLastCheque('', input as RequestOptions)
     })
 
+    testCashoutOptionsAssertions(async (input: unknown) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      return bee.cashoutLastCheque('', input as CashoutOptions)
+    })
+
     it('should not pass headers if no gas price is specified', async () => {
       cashoutLastChequeMock(testAddress).reply(201, CASHOUT_RESPONSE)
 
@@ -185,28 +197,6 @@ describe('BeeDebug class', () => {
       const bee = new BeeDebug(MOCK_SERVER_URL)
 
       return bee.cashoutLastCheque(input as string)
-    })
-
-    it('should throw error if passed wrong gas price input', async () => {
-      const bee = new BeeDebug(MOCK_SERVER_URL)
-
-      // @ts-ignore: Input testing
-      await expect(bee.cashoutLastCheque(testAddress, { gasPrice: 'asd' })).rejects.toThrow(TypeError)
-
-      // @ts-ignore: Input testing
-      await expect(bee.cashoutLastCheque(testAddress, { gasPrice: true })).rejects.toThrow(TypeError)
-      await expect(bee.cashoutLastCheque(testAddress, { gasPrice: '-1' })).rejects.toThrow(BeeArgumentError)
-    })
-
-    it('should throw error if passed wrong gas limit input', async () => {
-      const bee = new BeeDebug(MOCK_SERVER_URL)
-
-      // @ts-ignore: Input testing
-      await expect(bee.cashoutLastCheque(testAddress, { gasLimit: 'asd' })).rejects.toThrow(TypeError)
-
-      // @ts-ignore: Input testing
-      await expect(bee.cashoutLastCheque(testAddress, { gasLimit: true })).rejects.toThrow(TypeError)
-      await expect(bee.cashoutLastCheque(testAddress, { gasLimit: '-1' })).rejects.toThrow(BeeArgumentError)
     })
   })
 
@@ -360,6 +350,12 @@ describe('BeeDebug class', () => {
       batchID: BATCH_ID,
     }
 
+    testPostageBatchOptionsAssertions(async (input: unknown) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      return bee.createPostageBatch('10', 17, input as PostageBatchOptions)
+    })
+
     testRequestOptionsAssertions(async (input: unknown) => {
       const bee = new BeeDebug(MOCK_SERVER_URL)
 
@@ -380,25 +376,6 @@ describe('BeeDebug class', () => {
       const bee = new BeeDebug(MOCK_SERVER_URL)
       await expect(bee.createPostageBatch('10', 17, { gasPrice: '100' })).resolves.toEqual(BATCH_ID)
       assertAllIsDone()
-    })
-
-    it('should pass headers if immutable flag is specified', async () => {
-      createPostageBatchMock('10', '17', undefined, undefined, 'true').reply(201, BATCH_RESPONSE)
-
-      const bee = new BeeDebug(MOCK_SERVER_URL)
-      await expect(bee.createPostageBatch('10', 17, { immutableFlag: true })).resolves.toEqual(BATCH_ID)
-      assertAllIsDone()
-    })
-
-    it('should throw error if passed wrong gas price input', async () => {
-      const bee = new BeeDebug(MOCK_SERVER_URL)
-
-      // @ts-ignore: Input testing
-      await expect(bee.createPostageBatch('10', 17, { gasPrice: 'asd' })).rejects.toThrow(TypeError)
-
-      // @ts-ignore: Input testing
-      await expect(bee.createPostageBatch('10', 17, { gasPrice: true })).rejects.toThrow(TypeError)
-      await expect(bee.createPostageBatch('10', 17, { gasPrice: '-1' })).rejects.toThrow(BeeArgumentError)
     })
 
     it('should throw error if passed wrong immutable input', async () => {

--- a/test/unit/bee-debug-class.spec.ts
+++ b/test/unit/bee-debug-class.spec.ts
@@ -6,9 +6,9 @@ import {
   MOCK_SERVER_URL,
   withdrawTokensMock,
 } from './nock'
-import { BatchId, BeeArgumentError, BeeDebug } from '../../src'
-import { testAddress } from '../utils'
-import { testAddressAssertions, testBatchIdAssertion } from './assertions'
+import { BatchId, BeeArgumentError, BeeDebug, RequestOptions } from '../../src'
+import { testAddress, testBatchId } from '../utils'
+import { testAddressAssertions, testBatchIdAssertion, testRequestOptionsAssertions } from './assertions'
 
 const TRANSACTION_HASH = '36b7efd913ca4cf880b8eeac5093fa27b0825906c600685b6abdd6566e6cfe8f'
 const CASHOUT_RESPONSE = {
@@ -53,6 +53,12 @@ describe('BeeDebug class', () => {
   })
 
   describe('removePeer', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      return bee.removePeer('', input as RequestOptions)
+    })
+
     testAddressAssertions(async (input: unknown) => {
       const bee = new BeeDebug(MOCK_SERVER_URL)
 
@@ -61,6 +67,12 @@ describe('BeeDebug class', () => {
   })
 
   describe('pingPeer', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      return bee.pingPeer('', input as RequestOptions)
+    })
+
     testAddressAssertions(async (input: unknown) => {
       const bee = new BeeDebug(MOCK_SERVER_URL)
 
@@ -69,6 +81,12 @@ describe('BeeDebug class', () => {
   })
 
   describe('getPeerBalance', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      return bee.getPeerBalance('', input as RequestOptions)
+    })
+
     testAddressAssertions(async (input: unknown) => {
       const bee = new BeeDebug(MOCK_SERVER_URL)
 
@@ -77,6 +95,12 @@ describe('BeeDebug class', () => {
   })
 
   describe('getPastDueConsumptionPeerBalance', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      return bee.getPastDueConsumptionPeerBalance('', input as RequestOptions)
+    })
+
     testAddressAssertions(async (input: unknown) => {
       const bee = new BeeDebug(MOCK_SERVER_URL)
 
@@ -85,6 +109,12 @@ describe('BeeDebug class', () => {
   })
 
   describe('getLastChequesForPeer', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      return bee.getLastChequesForPeer('', input as RequestOptions)
+    })
+
     testAddressAssertions(async (input: unknown) => {
       const bee = new BeeDebug(MOCK_SERVER_URL)
 
@@ -93,6 +123,12 @@ describe('BeeDebug class', () => {
   })
 
   describe('getLastCashoutAction', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      return bee.getLastCashoutAction('', input as RequestOptions)
+    })
+
     testAddressAssertions(async (input: unknown) => {
       const bee = new BeeDebug(MOCK_SERVER_URL)
 
@@ -101,6 +137,12 @@ describe('BeeDebug class', () => {
   })
 
   describe('getSettlements', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      return bee.getSettlements('', input as RequestOptions)
+    })
+
     testAddressAssertions(async (input: unknown) => {
       const bee = new BeeDebug(MOCK_SERVER_URL)
 
@@ -109,6 +151,12 @@ describe('BeeDebug class', () => {
   })
 
   describe('cashoutLastCheque', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      return bee.cashoutLastCheque('', input as RequestOptions)
+    })
+
     it('should not pass headers if no gas price is specified', async () => {
       cashoutLastChequeMock(testAddress).reply(201, CASHOUT_RESPONSE)
 
@@ -168,6 +216,12 @@ describe('BeeDebug class', () => {
       transactionHash: TRANSACTION_HASH,
     }
 
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      return bee.withdrawTokens('1', '0', input as RequestOptions)
+    })
+
     it('should not pass headers if no gas price is specified', async () => {
       withdrawTokensMock('10').reply(201, CASHOUT_RESPONSE)
 
@@ -217,6 +271,12 @@ describe('BeeDebug class', () => {
       transactionHash: TRANSACTION_HASH,
     }
 
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      return bee.depositTokens('1', '0', input as RequestOptions)
+    })
+
     it('should not pass headers if no gas price is specified', async () => {
       depositTokensMock('10').reply(201, CASHOUT_RESPONSE)
 
@@ -261,6 +321,12 @@ describe('BeeDebug class', () => {
   })
 
   describe('retrieveExtendedTag', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      return bee.retrieveExtendedTag(0, input as RequestOptions)
+    })
+
     it('should throw exception for bad Tag', async () => {
       const bee = new BeeDebug(MOCK_SERVER_URL)
 
@@ -293,6 +359,12 @@ describe('BeeDebug class', () => {
     const BATCH_RESPONSE = {
       batchID: BATCH_ID,
     }
+
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      return bee.createPostageBatch('10', 10, input as RequestOptions)
+    })
 
     it('should not pass headers if no gas price is specified', async () => {
       createPostageBatchMock('10', '17').reply(201, BATCH_RESPONSE)
@@ -357,6 +429,12 @@ describe('BeeDebug class', () => {
   })
 
   describe('getPostageBatch', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      return bee.getPostageBatch(testBatchId, input as RequestOptions)
+    })
+
     testBatchIdAssertion(async (input: unknown) => {
       const bee = new BeeDebug(MOCK_SERVER_URL)
 
@@ -365,6 +443,12 @@ describe('BeeDebug class', () => {
   })
 
   describe('getPostageBatchBuckets', () => {
+    testRequestOptionsAssertions(async (input: unknown) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL)
+
+      return bee.getPostageBatchBuckets(testBatchId, input as RequestOptions)
+    })
+
     testBatchIdAssertion(async (input: unknown) => {
       const bee = new BeeDebug(MOCK_SERVER_URL)
 

--- a/test/unit/bee-debug-class.spec.ts
+++ b/test/unit/bee-debug-class.spec.ts
@@ -59,10 +59,10 @@ describe('BeeDebug class', () => {
   })
 
   describe('removePeer', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new BeeDebug(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL, beeOptions)
 
-      return bee.removePeer('', input as RequestOptions)
+      return bee.removePeer(testAddress, input as RequestOptions)
     })
 
     testAddressAssertions(async (input: unknown) => {
@@ -73,10 +73,10 @@ describe('BeeDebug class', () => {
   })
 
   describe('pingPeer', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new BeeDebug(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL, beeOptions)
 
-      return bee.pingPeer('', input as RequestOptions)
+      return bee.pingPeer(testAddress, input as RequestOptions)
     })
 
     testAddressAssertions(async (input: unknown) => {
@@ -87,10 +87,10 @@ describe('BeeDebug class', () => {
   })
 
   describe('getPeerBalance', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new BeeDebug(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL, beeOptions)
 
-      return bee.getPeerBalance('', input as RequestOptions)
+      return bee.getPeerBalance(testAddress, input as RequestOptions)
     })
 
     testAddressAssertions(async (input: unknown) => {
@@ -101,10 +101,10 @@ describe('BeeDebug class', () => {
   })
 
   describe('getPastDueConsumptionPeerBalance', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new BeeDebug(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL, beeOptions)
 
-      return bee.getPastDueConsumptionPeerBalance('', input as RequestOptions)
+      return bee.getPastDueConsumptionPeerBalance(testAddress, input as RequestOptions)
     })
 
     testAddressAssertions(async (input: unknown) => {
@@ -115,10 +115,10 @@ describe('BeeDebug class', () => {
   })
 
   describe('getLastChequesForPeer', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new BeeDebug(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL, beeOptions)
 
-      return bee.getLastChequesForPeer('', input as RequestOptions)
+      return bee.getLastChequesForPeer(testAddress, input as RequestOptions)
     })
 
     testAddressAssertions(async (input: unknown) => {
@@ -129,10 +129,10 @@ describe('BeeDebug class', () => {
   })
 
   describe('getLastCashoutAction', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new BeeDebug(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL, beeOptions)
 
-      return bee.getLastCashoutAction('', input as RequestOptions)
+      return bee.getLastCashoutAction(testAddress, input as RequestOptions)
     })
 
     testAddressAssertions(async (input: unknown) => {
@@ -143,10 +143,10 @@ describe('BeeDebug class', () => {
   })
 
   describe('getSettlements', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new BeeDebug(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL, beeOptions)
 
-      return bee.getSettlements('', input as RequestOptions)
+      return bee.getSettlements(testAddress, input as RequestOptions)
     })
 
     testAddressAssertions(async (input: unknown) => {
@@ -157,10 +157,10 @@ describe('BeeDebug class', () => {
   })
 
   describe('cashoutLastCheque', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new BeeDebug(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL, beeOptions)
 
-      return bee.cashoutLastCheque('', input as RequestOptions)
+      return bee.cashoutLastCheque(testAddress, input as RequestOptions)
     })
 
     testCashoutOptionsAssertions(async (input: unknown) => {
@@ -206,8 +206,8 @@ describe('BeeDebug class', () => {
       transactionHash: TRANSACTION_HASH,
     }
 
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new BeeDebug(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL, beeOptions)
 
       return bee.withdrawTokens('1', '0', input as RequestOptions)
     })
@@ -261,8 +261,8 @@ describe('BeeDebug class', () => {
       transactionHash: TRANSACTION_HASH,
     }
 
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new BeeDebug(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL, beeOptions)
 
       return bee.depositTokens('1', '0', input as RequestOptions)
     })
@@ -311,8 +311,8 @@ describe('BeeDebug class', () => {
   })
 
   describe('retrieveExtendedTag', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new BeeDebug(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL, beeOptions)
 
       return bee.retrieveExtendedTag(0, input as RequestOptions)
     })
@@ -356,10 +356,10 @@ describe('BeeDebug class', () => {
       return bee.createPostageBatch('10', 17, input as PostageBatchOptions)
     })
 
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new BeeDebug(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL, beeOptions)
 
-      return bee.createPostageBatch('10', 10, input as RequestOptions)
+      return bee.createPostageBatch('10', 17, input as RequestOptions)
     })
 
     it('should not pass headers if no gas price is specified', async () => {
@@ -406,8 +406,8 @@ describe('BeeDebug class', () => {
   })
 
   describe('getPostageBatch', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new BeeDebug(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL, beeOptions)
 
       return bee.getPostageBatch(testBatchId, input as RequestOptions)
     })
@@ -420,8 +420,8 @@ describe('BeeDebug class', () => {
   })
 
   describe('getPostageBatchBuckets', () => {
-    testRequestOptionsAssertions(async (input: unknown) => {
-      const bee = new BeeDebug(MOCK_SERVER_URL)
+    testRequestOptionsAssertions(async (input: unknown, beeOptions) => {
+      const bee = new BeeDebug(MOCK_SERVER_URL, beeOptions)
 
       return bee.getPostageBatchBuckets(testBatchId, input as RequestOptions)
     })


### PR DESCRIPTION
Closes #392 and also allows setting custom `fetch` instance which will be needed for the upload progress support.