### PR TITLE
docs: fix code block to prevent from escaping issues

### DIFF
--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -26,7 +26,7 @@ export interface FlexBytes<Min extends number, Max extends number> extends Uint8
 }
 
 /**
- * Type guard for Bytes<T> type
+ * Type guard for `Bytes<T>` type
  *
  * @param b       The byte array
  * @param length  The length of the byte array


### PR DESCRIPTION
When working with `bee-js-docs` the workflow included need to run a script that escapes some generated docs. Upon investigation I found out that this need was because one single comment that includes some special characters, so I have just put them into code block and now everything is fixed.