### PR TITLE
build: limit published scope of files

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "./dist/index.min.js": "./dist/index.browser.min.js",
     "data": "data.browser"
   },
+  "files": ["dist"],
   "types": "dist/src/index.d.ts",
   "scripts": {
     "prepare": "rimraf dist && npm run compile:types && npm run compile:browser --env mode=production && npm run compile:node --env mode=production",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "files": ["dist"],
   "types": "dist/src/index.d.ts",
   "scripts": {
-    "prepare": "rimraf dist && npm run compile:types && npm run compile:browser --env mode=production && npm run compile:node --env mode=production",
+    "prepublishOnly": "rimraf dist && npm run compile:types && npm run compile:browser --env mode=production && npm run compile:node --env mode=production",
     "compile:node": "webpack --progress --env target=node",
     "compile:types": "tsc --emitDeclarationOnly --declaration",
     "compile:browser": "webpack --progress --env target=web",
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@types/readable-stream": "^2.3.11",
+    "bufferutil": "^4.0.3",
     "cross-blob": "^2.0.1",
     "elliptic": "^6.5.4",
     "isomorphic-ws": "^4.0.1",
@@ -58,6 +59,7 @@
     "ky-universal": "^0.8.2",
     "readable-stream": "^3.6.0",
     "tar-js": "^0.3.0",
+    "utf-8-validate": "^5.0.5",
     "web-streams-polyfill": "^3.1.0",
     "ws": "^7.5.0"
   },
@@ -87,7 +89,6 @@
     "@typescript-eslint/parser": "^4.28.0",
     "babel-jest": "^27.0.5",
     "babel-loader": "^8.2.2",
-    "bufferutil": "^4.0.3",
     "debug": "^4.3.1",
     "depcheck": "^1.4.0",
     "eslint": "^7.29.0",
@@ -108,7 +109,6 @@
     "typedoc": "^0.21.0",
     "typedoc-plugin-markdown": "^3.10.0",
     "typescript": "^4.3.4",
-    "utf-8-validate": "^5.0.5",
     "webpack": "^5.40.0",
     "webpack-bundle-analyzer": "^4.4.1",
     "webpack-cli": "^4.7.2"


### PR DESCRIPTION
Packages `bufferutil` and `utf-8-validate` are peer dependencies of `ws` package so they should be installed accordingly.

