### PR TITLE
fix: convert buffer to uint8array for readablestream

### DIFF
--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -64,7 +64,11 @@ export function readableNodeToWeb(nodeStream: NodeReadableType): ReadableStream<
     start(controller) {
       nodeStream.pause()
       nodeStream.on('data', chunk => {
-        controller.enqueue(chunk)
+        if (Buffer.isBuffer(chunk)) {
+          controller.enqueue(new Uint8Array(chunk.buffer))
+        } else {
+          controller.enqueue(chunk)
+        }
         nodeStream.pause()
       })
       nodeStream.on('end', () => controller.close())


### PR DESCRIPTION
Currently, when we are converting Node's `Readable` to `ReadableStream` thanks to `node-fetch` the chunks are actually `Buffer`s even though in types we are proclaiming that they are `Uint8Arrays`. This fixes this by converting Buffer to `Uint8Array`. 