### PR TITLE
feat: direct upload support

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -167,6 +167,18 @@ export interface UploadOptions extends RequestOptions {
    * @link Tag
    */
   tag?: number
+
+  /**
+   * Determines if the uploaded data should be sent to the network immediately (eq. deferred=false) or in a deferred fashion (eq. deferred=true).
+   *
+   * With deferred style client uploads all the data to Bee node first and only then Bee node starts push the data to network itself. The progress of this upload can be tracked with tags.
+   * With non-deferred style client uploads the data to Bee which immediately starts pushing the data to network. The request is only finished once all the data was pushed through the Bee node to the network.
+   *
+   * In future there will be move to the non-deferred style and even the support for deferred upload will be removed from Bee itself.
+   *
+   * @default true
+   */
+  deferred?: boolean
 }
 
 export interface FileUploadOptions extends UploadOptions {

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -59,5 +59,7 @@ export function extractUploadHeaders(postageBatchId: BatchId, options?: UploadOp
 
   if (options?.tag) headers['swarm-tag'] = String(options.tag)
 
+  if (typeof options?.deferred === 'boolean') headers['swarm-deferred-upload'] = options.deferred.toString()
+
   return headers
 }

--- a/test/integration/bee-class.spec.ts
+++ b/test/integration/bee-class.spec.ts
@@ -56,6 +56,15 @@ describe('Bee class', () => {
 
       expect(downloadedChunk).toEqual(content)
     })
+
+    it('should upload and download chunk with direct upload', async () => {
+      const content = randomByteArray(100)
+
+      const reference = await bee.uploadChunk(getPostageBatch(), content, { deferred: false })
+      const downloadedChunk = await bee.downloadChunk(reference)
+
+      expect(downloadedChunk).toEqual(content)
+    })
   })
 
   describe('files', () => {
@@ -65,6 +74,18 @@ describe('Bee class', () => {
       const contentType = 'text/html'
 
       const result = await bee.uploadFile(getPostageBatch(), content, name, { contentType })
+      const file = await bee.downloadFile(result.reference)
+
+      expect(file.name).toEqual(name)
+      expect(file.data).toEqual(content)
+    })
+
+    it('should work with files and direct upload', async () => {
+      const content = new Uint8Array([1, 2, 3])
+      const name = 'hello.txt'
+      const contentType = 'text/html'
+
+      const result = await bee.uploadFile(getPostageBatch(), content, name, { contentType, deferred: false })
       const file = await bee.downloadFile(result.reference)
 
       expect(file.name).toEqual(name)
@@ -188,6 +209,12 @@ describe('Bee class', () => {
   describe('collections', () => {
     it('should work with directory with unicode filenames', async () => {
       const result = await bee.uploadFilesFromDirectory(getPostageBatch(), './test/data')
+
+      expect(result.reference.length).toEqual(REFERENCE_HEX_LENGTH)
+    })
+
+    it('should work with directory with unicode filenames and direct upload', async () => {
+      const result = await bee.uploadFilesFromDirectory(getPostageBatch(), './test/data', { deferred: false })
 
       expect(result.reference.length).toEqual(REFERENCE_HEX_LENGTH)
     })


### PR DESCRIPTION
Closes #482 

I am not sure how to properly test the direct upload behavior. The only idea I have is to upload large quantity of data and measure the time difference between the deferred and non-deferred uploads, but even that might not work for bee-factory setup so I have opted only to verify that the upload will not fail with the direct upload instead.