### PR TITLE
fix: use default import styles for esm compatibility

### DIFF
--- a/src/chunk/bmt.ts
+++ b/src/chunk/bmt.ts
@@ -1,4 +1,6 @@
-import { keccak256 } from 'js-sha3'
+// For ESM compatibility
+import pkg from 'js-sha3'
+const { keccak256 } = pkg
 import { BeeArgumentError } from '../utils/error'
 import { Bytes } from '../utils/bytes'
 import { keccak256Hash } from '../utils/hash'

--- a/src/chunk/signer.ts
+++ b/src/chunk/signer.ts
@@ -1,4 +1,9 @@
-import { ec, curve } from 'elliptic'
+import { curve } from 'elliptic'
+
+// For ESM compatibility
+import pkg from 'elliptic'
+const { ec } = pkg
+
 import { BeeError } from '../utils/error'
 import { Bytes, isBytes, assertBytes, wrapBytesWithHelpers } from '../utils/bytes'
 import { keccak256Hash } from '../utils/hash'

--- a/src/utils/eth.ts
+++ b/src/utils/eth.ts
@@ -1,4 +1,7 @@
-import { keccak256, sha3_256 } from 'js-sha3'
+// For ESM compatibility
+import pkg from 'js-sha3'
+const { keccak256, sha3_256 } = pkg
+
 import { BrandedString, Data, Signer } from '../types'
 import { HexString, hexToBytes, intToHex, makeHexString, assertHexString } from './hex'
 import { Bytes, assertBytes } from './bytes'

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,6 +1,9 @@
-import { keccak256, Message } from 'js-sha3'
+import { Message } from 'js-sha3'
 import { Bytes } from './bytes'
 
+// For ESM compatibility
+import pkg from 'js-sha3'
+const { keccak256 } = pkg
 /**
  * Helper function for calculating the keccak256 hash with
  * correct types.


### PR DESCRIPTION
@Cafe137 identified that when used the new 3.3.0 released in Node and ESM it will fail as:

```
> gateway-watch@1.0.0 start
> node --experimental-modules --es-module-specifier-resolution=node index.js

file:///Users/aron/Code/gateway-watch/node_modules/@ethersphere/bee-js/dist/mjs/utils/hash.js:1
import { keccak256 } from 'js-sha3';
         ^^^^^^^^^
SyntaxError: Named export 'keccak256' not found. The requested module 'js-sha3' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'js-sha3';
const { keccak256 } = pkg;
```

This should fix this.