### PR TITLE
fix: making readable-stream optional

### DIFF
--- a/build-fixup
+++ b/build-fixup
@@ -8,6 +8,8 @@ cat >dist/cjs/package.json <<!EOF
 {
     "type": "commonjs",
     "browser": {
+     "readable-stream": false,
+     "stream": false,
       "./utils/data.js": "./utils/data.browser.js",
       "./utils/collection.node.js": "./utils/collection.browser.js"
     }
@@ -18,6 +20,8 @@ cat >dist/mjs/package.json <<!EOF
 {
     "type": "module",
     "browser": {
+     "readable-stream": false,
+     "stream": false,
       "./utils/data.js": "./utils/data.browser.js",
       "./utils/collection.node.js": "./utils/collection.browser.js"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "js-sha3": "^0.8.0",
         "ky": "^0.25.1",
         "ky-universal": "^0.8.2",
-        "readable-stream": "^3.6.0",
         "semver": "^7.3.5",
         "tar-js": "^0.3.0",
         "utf-8-validate": "^5.0.8",
@@ -50,7 +49,6 @@
         "@typescript-eslint/parser": "^5.10.0",
         "babel-jest": "^27.0.5",
         "babel-loader": "^8.2.2",
-        "cross-env": "^7.0.3",
         "debug": "^4.3.1",
         "depcheck": "^1.4.3",
         "eslint": "^8.8.0",
@@ -5713,24 +5711,6 @@
       },
       "engines": {
         "node": "^10.17.0 || >=12.3.0"
-      }
-    },
-    "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -13595,6 +13575,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -14214,6 +14195,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -14222,6 +14204,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14948,7 +14931,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
@@ -19992,15 +19976,6 @@
       "requires": {
         "blob-polyfill": "^5.0.20210201",
         "fetch-blob": "^2.1.2"
-      }
-    },
-    "cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^7.0.1"
       }
     },
     "cross-spawn": {
@@ -25941,6 +25916,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -26433,6 +26409,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       },
@@ -26440,7 +26417,8 @@
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
         }
       }
     },
@@ -26947,7 +26925,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   },
   "types": "dist/types/index.d.ts",
   "browser": {
+    "readable-stream": false,
+    "stream": false,
     "./src/utils/data.ts": "./src/utils/data.browser.ts",
     "./dist/cjs/utils/data.js": "./dist/cjs/utils/data.browser.js",
     "./dist/mjs/utils/data.js": "./dist/mjs/utils/data.browser.js",
@@ -71,12 +73,14 @@
     "js-sha3": "^0.8.0",
     "ky": "^0.25.1",
     "ky-universal": "^0.8.2",
-    "readable-stream": "^3.6.0",
     "semver": "^7.3.5",
     "tar-js": "^0.3.0",
     "utf-8-validate": "^5.0.8",
     "web-streams-polyfill": "^3.1.0",
     "ws": "^8.5.0"
+  },
+  "peerDependencies": {
+    "readable-stream": "^3.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.6",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,11 @@
   "peerDependencies": {
     "readable-stream": "^3.6.0"
   },
+  "peerDependenciesMeta": {
+    "readable-stream": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@babel/core": "^7.14.6",
     "@babel/plugin-proposal-class-properties": "^7.16.7",

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -142,9 +142,14 @@ class NodeReadableWrapper extends NodeReadable {
  * @param webStream
  * @param options
  */
-export function readableWebToNode(webStream: ReadableStream<unknown>, options?: NodeReadableOptions): NodeReadableNative {
+export function readableWebToNode(
+  webStream: ReadableStream<unknown>,
+  options?: NodeReadableOptions,
+): NodeReadableNative {
   if (!NodeReadableStream && !NodeReadableNative) {
-    throw new Error('The Node\'s Readable is not available! If you are running this in browser you have to install readable-stream package and polyfill process and buffer!')
+    throw new Error(
+      "The Node's Readable is not available! If you are running this in browser you have to install readable-stream package and polyfill process and buffer!",
+    )
   }
 
   return new NodeReadableWrapper(webStream, options) as unknown as NodeReadableNative

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -1,9 +1,11 @@
-import type { Readable as NodeReadableType } from 'stream'
+import { Readable as NodeReadableNative, ReadableOptions as NodeReadableOptions } from 'stream'
 import { isStrictlyObject } from './type'
 import { ReadableStream } from 'web-streams-polyfill/ponyfill'
-import { Readable as NodeReadable, ReadableOptions as NodeReadableOptions } from 'readable-stream'
+import { Readable as NodeReadableStream } from 'readable-stream'
 
 import { Readable } from '../types'
+
+const NodeReadable = NodeReadableNative || NodeReadableStream || class {}
 
 /**
  * Validates if passed object is either browser's ReadableStream
@@ -11,7 +13,7 @@ import { Readable } from '../types'
  *
  * @param entry
  */
-export function isReadable(entry: unknown): entry is NodeReadableType {
+export function isReadable(entry: unknown): entry is Readable {
   return isReadableStream(entry) || isNodeReadable(entry)
 }
 
@@ -35,12 +37,12 @@ export function isReadableStream(entry: unknown): entry is ReadableStream {
   return false
 }
 
-export function isNodeReadable(entry: unknown): entry is NodeReadableType {
+export function isNodeReadable(entry: unknown): entry is NodeReadableNative {
   if (!isStrictlyObject(entry)) {
     return false
   }
 
-  const nodeReadable = entry as NodeReadableType
+  const nodeReadable = entry as NodeReadableNative
 
   if (typeof nodeReadable.pipe === 'function' && nodeReadable.readable && typeof nodeReadable._read === 'function') {
     return true
@@ -59,7 +61,7 @@ export function isNodeReadable(entry: unknown): entry is NodeReadableType {
  * @licence Apache License 2.0 https://github.com/gwicke/node-web-streams/blob/master/LICENSE
  * @param nodeStream
  */
-export function readableNodeToWeb(nodeStream: NodeReadableType): ReadableStream<Uint8Array> {
+export function readableNodeToWeb(nodeStream: NodeReadableNative): ReadableStream<Uint8Array> {
   return new ReadableStream({
     start(controller) {
       nodeStream.pause()
@@ -129,14 +131,23 @@ class NodeReadableWrapper extends NodeReadable {
  * Function that converts WHATWG ReadableStream into Node's Readable
  *
  * Taken over from https://github.com/gwicke/node-web-streams/blob/master/lib/conversions.js
- * Because it uses forked web-streams-polyfill that are outdated.
+ * Because it uses forked web-streams-polyfill that is outdated.
+ *
+ * **Warning!**
+ * If you want to use this function in browser you have to install readable-stream package and with your bundler
+ * polyfill `process` and `buffer` packages!
  *
  * @author https://github.com/gwicke
  * @licence Apache License 2.0 https://github.com/gwicke/node-web-streams/blob/master/LICENSE
  * @param webStream
+ * @param options
  */
-export function readableWebToNode(webStream: ReadableStream, options?: NodeReadableOptions): NodeReadableType {
-  return new NodeReadableWrapper(webStream, options) as unknown as NodeReadableType
+export function readableWebToNode(webStream: ReadableStream<unknown>, options?: NodeReadableOptions): NodeReadableNative {
+  if (!NodeReadableStream && !NodeReadableNative) {
+    throw new Error('The Node\'s Readable is not available! If you are running this in browser you have to install readable-stream package and polyfill process and buffer!')
+  }
+
+  return new NodeReadableWrapper(webStream, options) as unknown as NodeReadableNative
 }
 
 export function normalizeToReadableStream(stream: Readable): ReadableStream {


### PR DESCRIPTION
This PR makes the `readable-stream` dependency optional. It is needed only when `Utils.readableWebToNode()` function is used in browsers.

I have debugged this and verified with new example `browser-stream` that is placed here: https://github.com/ethersphere/examples-js/pull/26 and will be merged once the `bee-js@3.3.1` is out.