### PR TITLE
fix: add js suffix in imports for esm support with babel

### DIFF
--- a/.depcheckrc.json
+++ b/.depcheckrc.json
@@ -2,6 +2,7 @@
   "ignores": [
     "@babel/core",
     "@babel/plugin-proposal-class-properties",
+    "babel-plugin-add-import-extension",
     "@babel/plugin-transform-runtime",
     "@babel/preset-env",
     "@babel/preset-typescript",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "ws": "^8.5.0"
       },
       "devDependencies": {
+        "@babel/cli": "^7.17.0",
         "@babel/core": "^7.14.6",
         "@babel/plugin-proposal-class-properties": "^7.16.7",
         "@babel/plugin-transform-runtime": "^7.14.5",
@@ -49,6 +50,7 @@
         "@typescript-eslint/parser": "^5.10.0",
         "babel-jest": "^27.0.5",
         "babel-loader": "^8.2.2",
+        "babel-plugin-add-import-extension": "^1.6.0",
         "debug": "^4.3.1",
         "depcheck": "^1.4.3",
         "eslint": "^8.8.0",
@@ -87,6 +89,75 @@
         "readable-stream": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@babel/cli": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.17.0.tgz",
+      "integrity": "sha512-es10YH/ejXbg551vtnmEzIPe3MQRNOS644o3pf8vUr1tIeNzVNlP8BBvs1Eh7roh5A+k2fEHUas+ZptOWHA1fQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^4.0.1",
+        "convert-source-map": "^1.1.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.0.0",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.5.0"
+      },
+      "bin": {
+        "babel": "bin/babel.js",
+        "babel-external-helpers": "bin/babel-external-helpers.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "optionalDependencies": {
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
+        "chokidar": "^3.4.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3804,6 +3875,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/@nicolo-ribaudo/chokidar-2": {
+      "version": "2.1.8-no-fsevents.3",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
+      "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5147,6 +5225,18 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0",
         "webpack": ">=2"
+      }
+    },
+    "node_modules/babel-plugin-add-import-extension": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-import-extension/-/babel-plugin-add-import-extension-1.6.0.tgz",
+      "integrity": "sha512-JVSQPMzNzN/S4wPRoKQ7+u8PlkV//BPUMnfWVbr63zcE+6yHdU2Mblz10Vf7qe+6Rmu4svF5jG7JxdcPi9VvKg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0"
       }
     },
     "node_modules/babel-plugin-dynamic-import-node": {
@@ -7428,6 +7518,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -13030,6 +13126,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pirates": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
@@ -15788,6 +15893,53 @@
     }
   },
   "dependencies": {
+    "@babel/cli": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.17.0.tgz",
+      "integrity": "sha512-es10YH/ejXbg551vtnmEzIPe3MQRNOS644o3pf8vUr1tIeNzVNlP8BBvs1Eh7roh5A+k2fEHUas+ZptOWHA1fQ==",
+      "dev": true,
+      "requires": {
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
+        "chokidar": "^3.4.0",
+        "commander": "^4.0.1",
+        "convert-source-map": "^1.1.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.0.0",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        },
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
@@ -18508,6 +18660,13 @@
         }
       }
     },
+    "@nicolo-ribaudo/chokidar-2": {
+      "version": "2.1.8-no-fsevents.3",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
+      "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+      "dev": true,
+      "optional": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -19614,6 +19773,15 @@
         "loader-utils": "^1.4.0",
         "make-dir": "^3.1.0",
         "schema-utils": "^2.6.5"
+      }
+    },
+    "babel-plugin-add-import-extension": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-import-extension/-/babel-plugin-add-import-extension-1.6.0.tgz",
+      "integrity": "sha512-JVSQPMzNzN/S4wPRoKQ7+u8PlkV//BPUMnfWVbr63zcE+6yHdU2Mblz10Vf7qe+6Rmu4svF5jG7JxdcPi9VvKg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "babel-plugin-dynamic-import-node": {
@@ -21314,6 +21482,12 @@
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       }
+    },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -25598,6 +25772,12 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
       "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
+      "dev": true
+    },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
     },
     "pirates": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "prepublishOnly": "cross-env NODE_ENV=production npm run build",
     "build": "rimraf dist && npm run build:node && npm run build:types && npm run build:browser",
-    "build:node": "tsc -p tsconfig.json && tsc -p tsconfig-mjs.json && ./build-fixup",
+    "build:node": "tsc -p tsconfig.json && tsc -p tsconfig-mjs.json && ./build-fixup && babel --plugins \"babel-plugin-add-import-extension\" --out-dir dist/mjs/ dist/mjs/",
     "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist/types",
     "build:browser": "webpack --progress",
     "mock-ci": "npm run lint:check && npm run check:types && npm run test",
@@ -88,6 +88,7 @@
     }
   },
   "devDependencies": {
+    "@babel/cli": "^7.17.0",
     "@babel/core": "^7.14.6",
     "@babel/plugin-proposal-class-properties": "^7.16.7",
     "@babel/plugin-transform-runtime": "^7.14.5",
@@ -113,6 +114,7 @@
     "@typescript-eslint/parser": "^5.10.0",
     "babel-jest": "^27.0.5",
     "babel-loader": "^8.2.2",
+    "babel-plugin-add-import-extension": "^1.6.0",
     "debug": "^4.3.1",
     "depcheck": "^1.4.3",
     "eslint": "^8.8.0",

--- a/src/modules/debug/status.ts
+++ b/src/modules/debug/status.ts
@@ -2,7 +2,7 @@ import { http } from '../../utils/http'
 import type { Health, NodeInfo } from '../../types/debug'
 import { Ky } from '../../types'
 import { BeeVersions } from '../../types/debug'
-import getMajorSemver from 'semver/functions/major'
+import getMajorSemver from 'semver/functions/major.js'
 
 // Following lines bellow are automatically updated with GitHub Action when Bee version is updated
 // so if you are changing anything about them change the `update_bee` action accordingly!

--- a/src/types/web-streams-polyfill/index.d.ts
+++ b/src/types/web-streams-polyfill/index.d.ts
@@ -1,0 +1,6 @@
+/**
+ * This is type "alias" for the direct import of the web-streams-polyfill/dist/ponyfill.js
+ */
+declare module 'web-streams-polyfill/dist/ponyfill.js' {
+  export * from 'web-streams-polyfill/ponyfill'
+}

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -1,6 +1,6 @@
 import { Readable as NodeReadableNative, ReadableOptions as NodeReadableOptions } from 'stream'
 import { isStrictlyObject } from './type'
-import { ReadableStream } from 'web-streams-polyfill/ponyfill'
+import { ReadableStream } from 'web-streams-polyfill/dist/ponyfill.js'
 import { Readable as NodeReadableStream } from 'readable-stream'
 
 import { Readable } from '../types'


### PR DESCRIPTION
Potentially superseeds the #561 with using Babel to add the `.js` suffix and hopefully still functional tests.

Closes #555 