### PR TITLE
fix: drop readable stream

### DIFF
--- a/build-fixup
+++ b/build-fixup
@@ -8,7 +8,6 @@ cat >dist/cjs/package.json <<!EOF
 {
     "type": "commonjs",
     "browser": {
-     "readable-stream": false,
      "stream": false,
       "./utils/data.js": "./utils/data.browser.js",
       "./utils/collection.node.js": "./utils/collection.browser.js"
@@ -20,7 +19,6 @@ cat >dist/mjs/package.json <<!EOF
 {
     "type": "module",
     "browser": {
-     "readable-stream": false,
      "stream": false,
       "./utils/data.js": "./utils/data.browser.js",
       "./utils/collection.node.js": "./utils/collection.browser.js"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "types": "dist/types/index.d.ts",
   "browser": {
-    "readable-stream": false,
     "stream": false,
     "./src/utils/data.ts": "./src/utils/data.browser.ts",
     "./dist/cjs/utils/data.js": "./dist/cjs/utils/data.browser.js",
@@ -78,14 +77,6 @@
     "utf-8-validate": "^5.0.8",
     "web-streams-polyfill": "^3.1.0",
     "ws": "^8.5.0"
-  },
-  "peerDependencies": {
-    "readable-stream": "^3.6.0"
-  },
-  "peerDependenciesMeta": {
-    "readable-stream": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@babel/cli": "^7.17.0",

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -1,11 +1,10 @@
 import { Readable as NodeReadableNative, ReadableOptions as NodeReadableOptions } from 'stream'
 import { isStrictlyObject } from './type'
 import { ReadableStream } from 'web-streams-polyfill/dist/ponyfill.js'
-import { Readable as NodeReadableStream } from 'readable-stream'
 
 import { Readable } from '../types'
 
-const NodeReadable = NodeReadableNative || NodeReadableStream || class {}
+const NodeReadable = NodeReadableNative || class {}
 
 /**
  * Validates if passed object is either browser's ReadableStream
@@ -134,8 +133,7 @@ class NodeReadableWrapper extends NodeReadable {
  * Because it uses forked web-streams-polyfill that is outdated.
  *
  * **Warning!**
- * If you want to use this function in browser you have to install readable-stream package and with your bundler
- * polyfill `process` and `buffer` packages!
+ * If you want to use this function in browser you have to polyfill `stream` package with your bundler.
  *
  * @author https://github.com/gwicke
  * @licence Apache License 2.0 https://github.com/gwicke/node-web-streams/blob/master/LICENSE
@@ -146,9 +144,9 @@ export function readableWebToNode(
   webStream: ReadableStream<unknown>,
   options?: NodeReadableOptions,
 ): NodeReadableNative {
-  if (!NodeReadableStream && !NodeReadableNative) {
+  if (!NodeReadableNative) {
     throw new Error(
-      "The Node's Readable is not available! If you are running this in browser you have to install readable-stream package and polyfill process and buffer!",
+      "The Node's Readable is not available! If you are running this in browser you have to polyfill 'stream' package!",
     )
   }
 


### PR DESCRIPTION
I have realized that it does not really make sense to have `readable-stream` as peerDependency, because if the user would want to use it in the browser, then it would have to polyfill `process` and `buffer` packages, so we can just simplify the request to actually polyfill the `stream` package directly and simplify the code around.