### PR TITLE
chore: update to the bee api SwarmCommon v2 and Swarm v3

### DIFF
--- a/src/modules/debug/connectivity.ts
+++ b/src/modules/debug/connectivity.ts
@@ -19,7 +19,7 @@ export async function getPeers(ky: Ky): Promise<Peer[]> {
     responseType: 'json',
   })
 
-  return response.data.peers || []
+  return response.data.peers
 }
 
 export async function getBlocklist(ky: Ky): Promise<Peer[]> {
@@ -28,7 +28,7 @@ export async function getBlocklist(ky: Ky): Promise<Peer[]> {
     responseType: 'json',
   })
 
-  return response.data.peers || []
+  return response.data.peers
 }
 
 export async function removePeer(ky: Ky, peer: string): Promise<RemovePeerResponse> {

--- a/src/modules/debug/stamps.ts
+++ b/src/modules/debug/stamps.ts
@@ -25,7 +25,7 @@ export async function getAllPostageBatches(ky: Ky): Promise<DebugPostageBatch[]>
     responseType: 'json',
   })
 
-  return response.data.stamps || []
+  return response.data.stamps
 }
 
 export async function getPostageBatch(ky: Ky, postageBatchId: BatchId): Promise<DebugPostageBatch> {

--- a/src/modules/pinning.ts
+++ b/src/modules/pinning.ts
@@ -4,7 +4,7 @@ import { http } from '../utils/http'
 const PINNING_ENDPOINT = 'pins'
 
 export interface GetAllPinResponse {
-  references: Reference[] | null
+  references: Reference[]
 }
 
 /**
@@ -64,11 +64,5 @@ export async function getAllPins(ky: Ky): Promise<Reference[]> {
     path: `${PINNING_ENDPOINT}`,
   })
 
-  const result = response.data.references
-
-  if (result === null) {
-    return []
-  }
-
-  return result
+  return response.data.references
 }

--- a/src/types/debug.ts
+++ b/src/types/debug.ts
@@ -186,8 +186,8 @@ export interface RemovePeerResponse {
 export interface Bin {
   population: number
   connected: number
-  disconnectedPeers: Peer[] | null
-  connectedPeers: Peer[] | null
+  disconnectedPeers: Peer[]
+  connectedPeers: Peer[]
 }
 
 export interface Topology {


### PR DESCRIPTION
**Important: we decided to not merge this until next API breaking change.** The reasoning is, that the current bee-js works both for Bee v1.4 and v1.5 and by merging this PR we would stop supporting bee v1.4.


The bee v1.5.0 replaces the null responses with empty arrays on successful requests that have no result. With bee-js we have been already returning empty arrays for such responses but now we no longer need to do this check.

https://github.com/ethersphere/bee/pull/2821