### PR TITLE
refactor: simplifying feeds component

### DIFF
--- a/src/chunk/cac.ts
+++ b/src/chunk/cac.ts
@@ -1,7 +1,7 @@
-import { BrandedType } from '../types'
+import { BrandedType, PlainBytesReference } from '../types'
 import { BeeError } from '../utils/error'
 import { bmtHash } from './bmt'
-import { Bytes, bytesEqual, FlexBytes, flexBytesAtOffset, assertFlexBytes } from '../utils/bytes'
+import { assertFlexBytes, Bytes, bytesEqual, FlexBytes, flexBytesAtOffset } from '../utils/bytes'
 import { serializeBytes } from './serialize'
 import { makeSpan, SPAN_SIZE } from './span'
 
@@ -10,8 +10,6 @@ export const MAX_PAYLOAD_SIZE = 4096
 
 const CAC_SPAN_OFFSET = 0
 const CAC_PAYLOAD_OFFSET = CAC_SPAN_OFFSET + SPAN_SIZE
-
-export type ChunkAddress = Bytes<32>
 
 /**
  * General chunk interface for Swarm
@@ -27,7 +25,7 @@ export interface Chunk {
   span(): Bytes<8>
   payload(): FlexBytes<1, 4096>
 
-  address(): ChunkAddress
+  address(): PlainBytesReference
 }
 
 type ValidChunkData = BrandedType<Uint8Array, 'ValidChunkData'>
@@ -56,7 +54,7 @@ export function makeContentAddressedChunk(payloadBytes: Uint8Array): Chunk {
  * @param data          The chunk data
  * @param chunkAddress  The address of the chunk
  */
-export function isValidChunkData(data: unknown, chunkAddress: ChunkAddress): data is ValidChunkData {
+export function isValidChunkData(data: unknown, chunkAddress: PlainBytesReference): data is ValidChunkData {
   if (!(data instanceof Uint8Array)) return false
 
   const address = bmtHash(data)
@@ -72,7 +70,7 @@ export function isValidChunkData(data: unknown, chunkAddress: ChunkAddress): dat
  *
  * @returns a valid content addressed chunk or throws error
  */
-export function assertValidChunkData(data: unknown, chunkAddress: ChunkAddress): asserts data is ValidChunkData {
+export function assertValidChunkData(data: unknown, chunkAddress: PlainBytesReference): asserts data is ValidChunkData {
   if (!isValidChunkData(data, chunkAddress)) {
     throw new BeeError('Address of content address chunk does not match given data!')
   }

--- a/src/chunk/soc.ts
+++ b/src/chunk/soc.ts
@@ -5,15 +5,8 @@ import { keccak256Hash } from '../utils/hash'
 import { SPAN_SIZE } from './span'
 import { serializeBytes } from './serialize'
 import { BeeError } from '../utils/error'
-import {
-  Chunk,
-  ChunkAddress,
-  makeContentAddressedChunk,
-  MAX_PAYLOAD_SIZE,
-  MIN_PAYLOAD_SIZE,
-  assertValidChunkData,
-} from './cac'
-import { UploadOptions, Signature, Signer, BatchId, Reference, Ky } from '../types'
+import { Chunk, makeContentAddressedChunk, MAX_PAYLOAD_SIZE, MIN_PAYLOAD_SIZE, assertValidChunkData } from './cac'
+import { UploadOptions, Signature, Signer, BatchId, Reference, Ky, PlainBytesReference } from '../types'
 import { bytesToHex } from '../utils/hex'
 import * as socAPI from '../modules/soc'
 import * as chunkAPI from '../modules/chunk'
@@ -63,7 +56,7 @@ function recoverChunkOwner(data: Uint8Array): EthAddress {
  *
  * @returns a single owner chunk or throws error
  */
-export function makeSingleOwnerChunkFromData(data: Uint8Array, address: ChunkAddress): SingleOwnerChunk {
+export function makeSingleOwnerChunkFromData(data: Uint8Array, address: PlainBytesReference): SingleOwnerChunk {
   const ownerAddress = recoverChunkOwner(data)
   const identifier = bytesAtOffset(data, SOC_IDENTIFIER_OFFSET, IDENTIFIER_SIZE)
   const socAddress = keccak256Hash(identifier, ownerAddress)
@@ -87,7 +80,7 @@ export function makeSingleOwnerChunkFromData(data: Uint8Array, address: ChunkAdd
   }
 }
 
-export function makeSOCAddress(identifier: Identifier, address: EthAddress): ChunkAddress {
+export function makeSOCAddress(identifier: Identifier, address: EthAddress): PlainBytesReference {
   return keccak256Hash(identifier, address)
 }
 

--- a/src/feed/identifier.ts
+++ b/src/feed/identifier.ts
@@ -1,0 +1,40 @@
+import { FEED_INDEX_HEX_LENGTH, Topic } from '../types'
+import { Identifier } from '../chunk/soc'
+import { keccak256Hash } from '../utils/hash'
+import { hexToBytes, makeHexString } from '../utils/hex'
+import { writeUint64BigEndian } from '../utils/uint64'
+import { Epoch, Index, IndexBytes } from './index'
+
+function isEpoch(epoch: unknown): epoch is Epoch {
+  return typeof epoch === 'object' && epoch !== null && 'time' in epoch && 'level' in epoch
+}
+
+function hashFeedIdentifier(topic: Topic, index: IndexBytes): Identifier {
+  return keccak256Hash(hexToBytes(topic), index)
+}
+
+function makeSequentialFeedIdentifier(topic: Topic, index: number): Identifier {
+  const indexBytes = writeUint64BigEndian(index)
+
+  return hashFeedIdentifier(topic, indexBytes)
+}
+
+function makeFeedIndexBytes(s: string): IndexBytes {
+  const hex = makeHexString(s, FEED_INDEX_HEX_LENGTH)
+
+  return hexToBytes(hex)
+}
+
+export function makeFeedIdentifier(topic: Topic, index: Index): Identifier {
+  if (typeof index === 'number') {
+    return makeSequentialFeedIdentifier(topic, index)
+  } else if (typeof index === 'string') {
+    const indexBytes = makeFeedIndexBytes(index)
+
+    return hashFeedIdentifier(topic, indexBytes)
+  } else if (isEpoch(index)) {
+    throw new TypeError('epoch is not yet implemented')
+  }
+
+  return hashFeedIdentifier(topic, index)
+}

--- a/src/feed/index.ts
+++ b/src/feed/index.ts
@@ -1,38 +1,36 @@
 import { keccak256Hash } from '../utils/hash'
 import { serializeBytes } from '../chunk/serialize'
-import { Identifier, uploadSingleOwnerChunkData, makeSingleOwnerChunkFromData } from '../chunk/soc'
 import { FeedUpdateOptions, fetchLatestFeedUpdate, FetchFeedUpdateResponse } from '../modules/feed'
+import { makeSingleOwnerChunkFromData, uploadSingleOwnerChunkData } from '../chunk/soc'
 import {
-  REFERENCE_HEX_LENGTH,
-  Reference,
-  UploadOptions,
-  ENCRYPTED_REFERENCE_HEX_LENGTH,
-  ENCRYPTED_REFERENCE_BYTES_LENGTH,
-  REFERENCE_BYTES_LENGTH,
-  Signer,
-  FeedReader,
-  FeedWriter,
-  Topic,
   Address,
   BatchId,
+  BytesReference,
+  FEED_INDEX_HEX_LENGTH,
+  FeedReader,
+  FeedWriter,
   Ky,
+  PlainBytesReference,
+  Reference,
+  Signer,
+  Topic,
+  UploadOptions,
 } from '../types'
-import { Bytes, makeBytes, bytesAtOffset } from '../utils/bytes'
+import { Bytes, bytesAtOffset, makeBytes } from '../utils/bytes'
 import { BeeResponseError } from '../utils/error'
-import { bytesToHex, HexString, hexToBytes, makeHexString } from '../utils/hex'
+import { bytesToHex, hexToBytes, HexString, makeHexString } from '../utils/hex'
 import { readUint64BigEndian, writeUint64BigEndian } from '../utils/uint64'
 import * as chunkAPI from '../modules/chunk'
 import { EthAddress, HexEthAddress, makeHexEthAddress } from '../utils/eth'
 
 import type { FeedType } from './type'
 import { assertAddress } from '../utils/type'
+import { makeFeedIdentifier } from './identifier'
+import { makeBytesReference } from '../utils/reference'
 
 const TIMESTAMP_PAYLOAD_OFFSET = 0
 const TIMESTAMP_PAYLOAD_SIZE = 8
 const REFERENCE_PAYLOAD_OFFSET = TIMESTAMP_PAYLOAD_SIZE
-const REFERENCE_PAYLOAD_MIN_SIZE = 32
-const REFERENCE_PAYLOAD_MAX_SIZE = 64
-const INDEX_HEX_LENGTH = 16
 
 export interface Epoch {
   time: number
@@ -44,64 +42,9 @@ export type Index = number | Epoch | IndexBytes | string
 
 export interface FeedUploadOptions extends UploadOptions, FeedUpdateOptions {}
 
-type PlainChunkReference = Bytes<32>
-type EncryptedChunkReference = Bytes<64>
-export type ChunkReference = PlainChunkReference | EncryptedChunkReference
-
 export interface FeedUpdate {
   timestamp: number
-  reference: ChunkReference
-}
-
-export function isEpoch(epoch: unknown): epoch is Epoch {
-  return typeof epoch === 'object' && epoch !== null && 'time' in epoch && 'level' in epoch
-}
-
-function hashFeedIdentifier(topic: Topic, index: IndexBytes): Identifier {
-  return keccak256Hash(hexToBytes(topic), index)
-}
-
-export function makeSequentialFeedIdentifier(topic: Topic, index: number): Identifier {
-  const indexBytes = writeUint64BigEndian(index)
-
-  return hashFeedIdentifier(topic, indexBytes)
-}
-
-export function makeFeedIndexBytes(s: string): IndexBytes {
-  const hex = makeHexString(s, INDEX_HEX_LENGTH)
-
-  return hexToBytes(hex)
-}
-
-export function makeFeedIdentifier(topic: Topic, index: Index): Identifier {
-  if (typeof index === 'number') {
-    return makeSequentialFeedIdentifier(topic, index)
-  } else if (typeof index === 'string') {
-    const indexBytes = makeFeedIndexBytes(index)
-
-    return hashFeedIdentifier(topic, indexBytes)
-  } else if (isEpoch(index)) {
-    throw new TypeError('epoch is not yet implemented')
-  }
-
-  return hashFeedIdentifier(topic, index)
-}
-
-export async function uploadFeedUpdate(
-  ky: Ky,
-  signer: Signer,
-  topic: Topic,
-  index: Index,
-  reference: ChunkReference,
-  postageBatchId: BatchId,
-  options?: FeedUploadOptions,
-): Promise<Reference> {
-  const identifier = makeFeedIdentifier(topic, index)
-  const at = options?.at ?? Date.now() / 1000.0
-  const timestamp = writeUint64BigEndian(at)
-  const payloadBytes = serializeBytes(timestamp, reference)
-
-  return uploadSingleOwnerChunkData(ky, signer, postageBatchId, identifier, payloadBytes, options)
+  reference: BytesReference
 }
 
 export async function findNextIndex(
@@ -109,11 +52,11 @@ export async function findNextIndex(
   owner: HexEthAddress,
   topic: Topic,
   options?: FeedUpdateOptions,
-): Promise<HexString<typeof INDEX_HEX_LENGTH>> {
+): Promise<HexString<typeof FEED_INDEX_HEX_LENGTH>> {
   try {
     const feedUpdate = await fetchLatestFeedUpdate(ky, owner, topic, options)
 
-    return makeHexString(feedUpdate.feedIndexNext, INDEX_HEX_LENGTH)
+    return makeHexString(feedUpdate.feedIndexNext, FEED_INDEX_HEX_LENGTH)
   } catch (e) {
     if (e instanceof BeeResponseError && e.status === 404) {
       return bytesToHex(makeBytes(8))
@@ -126,38 +69,37 @@ export async function updateFeed(
   ky: Ky,
   signer: Signer,
   topic: Topic,
-  reference: ChunkReference,
+  reference: BytesReference,
   postageBatchId: BatchId,
   options?: FeedUploadOptions,
+  index: Index = 'latest',
 ): Promise<Reference> {
   const ownerHex = makeHexEthAddress(signer.address)
-  const nextIndex = await findNextIndex(ky, ownerHex, topic, options)
+  const nextIndex = index === 'latest' ? await findNextIndex(ky, ownerHex, topic, options) : index
 
-  return uploadFeedUpdate(ky, signer, topic, nextIndex, reference, postageBatchId, options)
+  const identifier = makeFeedIdentifier(topic, nextIndex)
+  const at = options?.at ?? Date.now() / 1000.0
+  const timestamp = writeUint64BigEndian(at)
+  const payloadBytes = serializeBytes(timestamp, reference)
+
+  return uploadSingleOwnerChunkData(ky, signer, postageBatchId, identifier, payloadBytes, options)
 }
 
-function verifyChunkReferenceAtOffset(offset: number, data: Uint8Array): ChunkReference {
-  try {
-    return bytesAtOffset(data, offset, REFERENCE_PAYLOAD_MAX_SIZE)
-  } catch (e) {
-    return bytesAtOffset(data, offset, REFERENCE_PAYLOAD_MIN_SIZE)
-  }
-}
+export function getFeedUpdateChunkReference(owner: EthAddress, topic: Topic, index: Index): PlainBytesReference {
+  const identifier = makeFeedIdentifier(topic, index)
 
-export function verifyChunkReference(data: Uint8Array): ChunkReference {
-  return verifyChunkReferenceAtOffset(0, data)
+  return keccak256Hash(identifier, owner)
 }
 
 export async function downloadFeedUpdate(ky: Ky, owner: EthAddress, topic: Topic, index: Index): Promise<FeedUpdate> {
-  const identifier = makeFeedIdentifier(topic, index)
-  const address = keccak256Hash(identifier, owner)
+  const address = getFeedUpdateChunkReference(owner, topic, index)
   const addressHex = bytesToHex(address)
   const data = await chunkAPI.download(ky, addressHex)
   const soc = makeSingleOwnerChunkFromData(data, address)
   const payload = soc.payload()
   const timestampBytes = bytesAtOffset(payload, TIMESTAMP_PAYLOAD_OFFSET, TIMESTAMP_PAYLOAD_SIZE)
   const timestamp = readUint64BigEndian(timestampBytes)
-  const reference = verifyChunkReferenceAtOffset(REFERENCE_PAYLOAD_OFFSET, payload)
+  const reference = makeBytesReference(payload, REFERENCE_PAYLOAD_OFFSET)
 
   return {
     timestamp,
@@ -186,37 +128,14 @@ export function makeFeedReader(ky: Ky, type: FeedType, topic: Topic, owner: HexE
   }
 }
 
-function makeChunkReference(reference: ChunkReference | Reference): ChunkReference {
-  if (typeof reference === 'string') {
-    try {
-      // Non-encrypted chunk hex string reference
-      const hexReference = makeHexString(reference, REFERENCE_HEX_LENGTH)
-
-      return hexToBytes<typeof REFERENCE_BYTES_LENGTH>(hexReference)
-    } catch (e) {
-      if (!(e instanceof TypeError)) {
-        throw e
-      }
-
-      // Encrypted chunk hex string reference
-      const hexReference = makeHexString(reference, ENCRYPTED_REFERENCE_HEX_LENGTH)
-
-      return hexToBytes<typeof ENCRYPTED_REFERENCE_BYTES_LENGTH>(hexReference)
-    }
-  } else if (reference instanceof Uint8Array) {
-    return verifyChunkReference(reference)
-  }
-  throw new TypeError('invalid chunk reference')
-}
-
 export function makeFeedWriter(ky: Ky, type: FeedType, topic: Topic, signer: Signer): FeedWriter {
   const upload = async (
     postageBatchId: string | Address,
-    reference: ChunkReference | Reference,
+    reference: BytesReference | Reference,
     options?: FeedUploadOptions,
   ) => {
     assertAddress(postageBatchId)
-    const canonicalReference = makeChunkReference(reference)
+    const canonicalReference = makeBytesReference(reference)
 
     return updateFeed(ky, signer, topic, canonicalReference, postageBatchId, { ...options, type })
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 import type { Identifier, SingleOwnerChunk } from '../chunk/soc'
-import type { ChunkReference, FeedUploadOptions } from '../feed'
+import type { FeedUploadOptions } from '../feed'
 import type { FeedType } from '../feed/type'
 import type { FeedUpdateOptions, FetchFeedUpdateResponse } from '../modules/feed'
 import type { Bytes } from '../utils/bytes'
@@ -48,6 +48,8 @@ export const STAMPS_DEPTH_MAX = 255
 export const TAGS_LIMIT_MIN = 1
 export const TAGS_LIMIT_MAX = 1000
 
+export const FEED_INDEX_HEX_LENGTH = 16
+
 /**
  * Generic reference that can be either non-encrypted reference which is a hex string of length 64 or encrypted
  * reference which is a hex string of length 128.
@@ -57,6 +59,11 @@ export const TAGS_LIMIT_MAX = 1000
  * @see [Bee docs - Store with Encryption](https://docs.ethswarm.org/docs/access-the-swarm/store-with-encryption)
  */
 export type Reference = HexString<typeof REFERENCE_HEX_LENGTH> | HexString<typeof ENCRYPTED_REFERENCE_HEX_LENGTH>
+
+export type PlainBytesReference = Bytes<typeof REFERENCE_BYTES_LENGTH>
+export type EncryptedBytesReference = Bytes<typeof ENCRYPTED_REFERENCE_BYTES_LENGTH>
+export type BytesReference = PlainBytesReference | EncryptedBytesReference
+
 export type PublicKey = HexString<typeof PUBKEY_HEX_LENGTH>
 
 export type Address = HexString<typeof ADDRESS_HEX_LENGTH>
@@ -421,7 +428,7 @@ export interface FeedWriter extends FeedReader {
    */
   upload(
     postageBatchId: string | BatchId,
-    reference: ChunkReference | Reference,
+    reference: BytesReference | Reference,
     options?: FeedUploadOptions,
   ): Promise<Reference>
 }

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -36,6 +36,22 @@ export function isBytes<Length extends number>(b: unknown, length: Length): b is
 }
 
 /**
+ * Function that verifies if passed data are Bytes and if the array has "length" number of bytes under given offset.
+ * @param data
+ * @param offset
+ * @param length
+ */
+export function hasBytesAtOffset(data: unknown, offset: number, length: number): boolean {
+  if (!(data instanceof Uint8Array)) {
+    throw new TypeError('Data has to an Uint8Array!')
+  }
+
+  const offsetBytes = data.slice(offset, offset + length)
+
+  return isBytes(offsetBytes, length)
+}
+
+/**
  * Verifies if a byte array has a certain length
  *
  * @param b       The byte array

--- a/src/utils/reference.ts
+++ b/src/utils/reference.ts
@@ -6,7 +6,7 @@ import {
   REFERENCE_BYTES_LENGTH,
   REFERENCE_HEX_LENGTH,
 } from '../types'
-import { bytesAtOffset } from './bytes'
+import { bytesAtOffset, hasBytesAtOffset } from './bytes'
 import { hexToBytes, makeHexString } from './hex'
 
 export function makeBytesReference(reference: Uint8Array | BytesReference | Reference, offset = 0): BytesReference {
@@ -31,9 +31,9 @@ export function makeBytesReference(reference: Uint8Array | BytesReference | Refe
       return hexToBytes<typeof ENCRYPTED_REFERENCE_BYTES_LENGTH>(hexReference)
     }
   } else if (reference instanceof Uint8Array) {
-    try {
+    if (hasBytesAtOffset(reference, offset, ENCRYPTED_REFERENCE_BYTES_LENGTH)) {
       return bytesAtOffset(reference, offset, ENCRYPTED_REFERENCE_BYTES_LENGTH)
-    } catch (e) {
+    } else if (hasBytesAtOffset(reference, offset, REFERENCE_BYTES_LENGTH)) {
       return bytesAtOffset(reference, offset, REFERENCE_BYTES_LENGTH)
     }
   }

--- a/src/utils/reference.ts
+++ b/src/utils/reference.ts
@@ -1,0 +1,41 @@
+import {
+  BytesReference,
+  ENCRYPTED_REFERENCE_BYTES_LENGTH,
+  ENCRYPTED_REFERENCE_HEX_LENGTH,
+  Reference,
+  REFERENCE_BYTES_LENGTH,
+  REFERENCE_HEX_LENGTH,
+} from '../types'
+import { bytesAtOffset } from './bytes'
+import { hexToBytes, makeHexString } from './hex'
+
+export function makeBytesReference(reference: Uint8Array | BytesReference | Reference, offset = 0): BytesReference {
+  if (typeof reference === 'string') {
+    if (offset) {
+      throw new Error('Offset property can be set only for UintArray reference!')
+    }
+
+    try {
+      // Non-encrypted chunk hex string reference
+      const hexReference = makeHexString(reference, REFERENCE_HEX_LENGTH)
+
+      return hexToBytes<typeof REFERENCE_BYTES_LENGTH>(hexReference)
+    } catch (e) {
+      if (!(e instanceof TypeError)) {
+        throw e
+      }
+
+      // Encrypted chunk hex string reference
+      const hexReference = makeHexString(reference, ENCRYPTED_REFERENCE_HEX_LENGTH)
+
+      return hexToBytes<typeof ENCRYPTED_REFERENCE_BYTES_LENGTH>(hexReference)
+    }
+  } else if (reference instanceof Uint8Array) {
+    try {
+      return bytesAtOffset(reference, offset, ENCRYPTED_REFERENCE_BYTES_LENGTH)
+    } catch (e) {
+      return bytesAtOffset(reference, offset, REFERENCE_BYTES_LENGTH)
+    }
+  }
+  throw new TypeError('invalid chunk reference')
+}

--- a/test/integration/bee-class.spec.ts
+++ b/test/integration/bee-class.spec.ts
@@ -1,7 +1,6 @@
-import { Bee, BeeDebug, BeeResponseError, Collection, PssSubscription } from '../../src'
+import { Bee, BeeDebug, BeeResponseError, BytesReference, Collection, PssSubscription } from '../../src'
 import { makeSigner } from '../../src/chunk/signer'
 import { makeSOCAddress, uploadSingleOwnerChunkData } from '../../src/chunk/soc'
-import { ChunkReference } from '../../src/feed'
 import * as bzz from '../../src/modules/bzz'
 import { REFERENCE_HEX_LENGTH } from '../../src/types'
 import { makeBytes } from '../../src/utils/bytes'
@@ -459,7 +458,7 @@ describe('Bee class', () => {
         expect(firstUpdateReferenceResponse.reference).toEqual(bytesToHex(referenceZero))
         expect(firstUpdateReferenceResponse.feedIndex).toEqual('0000000000000000')
 
-        const referenceOne = new Uint8Array([...new Uint8Array([1]), ...new Uint8Array(31)]) as ChunkReference
+        const referenceOne = new Uint8Array([...new Uint8Array([1]), ...new Uint8Array(31)]) as BytesReference
 
         await feed.upload(getPostageBatch(), referenceOne)
         const secondUpdateReferenceResponse = await feed.download()
@@ -487,7 +486,7 @@ describe('Bee class', () => {
         expect(firstLatestUpdate.reference).toEqual(bytesToHex(referenceZero))
         expect(firstLatestUpdate.feedIndex).toEqual('0000000000000000')
 
-        const referenceOne = new Uint8Array([...new Uint8Array([1]), ...new Uint8Array(31)]) as ChunkReference
+        const referenceOne = new Uint8Array([...new Uint8Array([1]), ...new Uint8Array(31)]) as BytesReference
         await feed.upload(getPostageBatch(), referenceOne)
 
         const secondLatestUpdate = await feed.download()
@@ -498,7 +497,7 @@ describe('Bee class', () => {
           ...new Uint8Array([1]),
           ...new Uint8Array([1]),
           ...new Uint8Array(30),
-        ]) as ChunkReference
+        ]) as BytesReference
         await feed.upload(getPostageBatch(), referenceTwo)
 
         const thirdLatestUpdate = await feed.download()

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -3,11 +3,18 @@ import { ReadableStream as ReadableStreamPolyfill } from 'web-streams-polyfill'
 
 import ky from 'ky-universal'
 
-import type { Ky, BeeGenericResponse, Reference, Address, BatchId, PostageBatch } from '../src/types'
+import type {
+  Ky,
+  BeeGenericResponse,
+  Reference,
+  Address,
+  BatchId,
+  PostageBatch,
+  PlainBytesReference,
+} from '../src/types'
 import { bytesToHex, HexString } from '../src/utils/hex'
 import { deleteChunkFromLocalStorage } from '../src/modules/debug/chunk'
 import { BeeResponseError } from '../src'
-import { ChunkAddress } from '../src/chunk/cac'
 import { assertBytes } from '../src/utils/bytes'
 import * as stamps from '../src/modules/debug/stamps'
 
@@ -278,7 +285,7 @@ export function beePeerDebugKy(): Ky {
  *
  * @param address  Swarm address of chunk
  */
-export async function tryDeleteChunkFromLocalStorage(address: string | ChunkAddress): Promise<void> {
+export async function tryDeleteChunkFromLocalStorage(address: string | PlainBytesReference): Promise<void> {
   if (typeof address !== 'string') {
     assertBytes(address, 32)
     address = bytesToHex(address)


### PR DESCRIPTION
This refactor mainly aims on simplifying the `feeds/index.ts` file and it does so with:

 - deduping generic constants using already existing ones in the `types/index.ts` file
 - creating `BytesReference` type that handles references in bytes
 - moving chunk specific functions into more appropriate places
 - Splitting identifier functionality into separate file