### PR TITLE
docs: remove dependency status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Bee-js
 
 [![Tests](https://github.com/ethersphere/bee-js/actions/workflows/tests.yaml/badge.svg)](https://github.com/ethersphere/bee-js/actions/workflows/tests.yaml)
-[![Dependency Status](https://david-dm.org/ethersphere/bee-js.svg?style=flat-square)](https://david-dm.org/ethersphere/bee-js)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fethersphere%2Fbee-js.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fethersphere%2Fbee-js?ref=badge_shield)
 [![](https://img.shields.io/badge/made%20by-Swarm-blue.svg?style=flat-square)](https://swarm.ethereum.org/)
 [![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)


### PR DESCRIPTION
The dependency status badge is almost always broken for me. This gives the impression that the project is unmaintained. I think it would be better to remove it (also applicable for other projects).

<img width="871" alt="Screenshot 2022-05-18 at 13 16 59" src="https://user-images.githubusercontent.com/230163/169027160-ec63d0f0-9967-4cee-98da-55d14f15c4e2.png">
