### PR TITLE
feat: cids support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.3.4",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@ethersphere/swarm-cid": "^0.1.0",
         "@types/readable-stream": "^2.3.13",
         "bufferutil": "^4.0.6",
         "elliptic": "^6.5.4",
@@ -2505,6 +2506,18 @@
         "bee": "1.5.1-d0a77598",
         "beeApiVersion": "3.0.0",
         "beeDebugApiVersion": "2.0.0",
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@ethersphere/swarm-cid": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersphere/swarm-cid/-/swarm-cid-0.1.0.tgz",
+      "integrity": "sha512-n+n+w5RJBPm7CiPf8TIgNFIRMo4bLh5bYpZxHObgCaxFW8WNZ4UGfqg+qjS/jEr+A3Mmp0lugKDvd8GnfFy7JQ==",
+      "dependencies": {
+        "multiformats": "^9.5.4"
+      },
+      "engines": {
         "node": ">=12.0.0",
         "npm": ">=6.0.0"
       }
@@ -13054,6 +13067,11 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/multiformats": {
+      "version": "9.6.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.5.tgz",
+      "integrity": "sha512-vMwf/FUO+qAPvl3vlSZEgEVFY/AxeZq5yg761ScF3CZsXgmTi/HGkicUiNN0CI4PW8FiY2P0OLklOcmQjdQJhw=="
+    },
     "node_modules/multimatch": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
@@ -18066,6 +18084,14 @@
         "utf-8-validate": "^5.0.9",
         "web-streams-polyfill": "^4.0.0-beta.1",
         "ws": "^8.5.0"
+      }
+    },
+    "@ethersphere/swarm-cid": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersphere/swarm-cid/-/swarm-cid-0.1.0.tgz",
+      "integrity": "sha512-n+n+w5RJBPm7CiPf8TIgNFIRMo4bLh5bYpZxHObgCaxFW8WNZ4UGfqg+qjS/jEr+A3Mmp0lugKDvd8GnfFy7JQ==",
+      "requires": {
+        "multiformats": "^9.5.4"
       }
     },
     "@fluffy-spoon/substitute": {
@@ -26153,6 +26179,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "multiformats": {
+      "version": "9.6.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.5.tgz",
+      "integrity": "sha512-vMwf/FUO+qAPvl3vlSZEgEVFY/AxeZq5yg761ScF3CZsXgmTi/HGkicUiNN0CI4PW8FiY2P0OLklOcmQjdQJhw=="
     },
     "multimatch": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "bee": "bee-factory start"
   },
   "dependencies": {
+    "@ethersphere/swarm-cid": "^0.1.0",
     "@types/readable-stream": "^2.3.13",
     "bufferutil": "^4.0.6",
     "elliptic": "^6.5.4",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,9 +62,13 @@ export type Reference = HexString<typeof REFERENCE_HEX_LENGTH> | HexString<typeo
 
 /**
  * Type that represents either Swarm's reference in hex string or ESN domain (something.eth).
- * This is the type used on all the download functions.
  */
 export type ReferenceOrEns = Reference | string
+
+/**
+ * Type that represents either Swarm's reference in hex string, ESN domain (something.eth) or CID using one of the Swarm's codecs.
+ */
+export type ReferenceCidOrEns = ReferenceOrEns | string
 
 export type PlainBytesReference = Bytes<typeof REFERENCE_BYTES_LENGTH>
 export type EncryptedBytesReference = Bytes<typeof ENCRYPTED_REFERENCE_BYTES_LENGTH>
@@ -145,6 +149,10 @@ export interface BeeOptions extends RequestOptions {
    * Function that registers listener callback for all incoming HTTP responses that Bee instance made.
    */
   onResponse?: HookCallback<BeeResponse>
+}
+
+export interface UploadResultWithCid extends UploadResult {
+  cid: string
 }
 
 /**

--- a/test/integration/bee-class.spec.ts
+++ b/test/integration/bee-class.spec.ts
@@ -79,6 +79,18 @@ describe('Bee class', () => {
       expect(file.data).toEqual(content)
     })
 
+    it('should work with files and CIDs', async () => {
+      const content = new Uint8Array([1, 2, 3])
+      const name = 'hello.txt'
+      const contentType = 'text/html'
+
+      const result = await bee.uploadFile(getPostageBatch(), content, name, { contentType })
+      const file = await bee.downloadFile(result.cid)
+
+      expect(file.name).toEqual(name)
+      expect(file.data).toEqual(content)
+    })
+
     it('should work with files and direct upload', async () => {
       const content = new Uint8Array([1, 2, 3])
       const name = 'hello.txt'
@@ -231,6 +243,21 @@ describe('Bee class', () => {
 
       expect(file.name).toEqual(directoryStructure[0].path)
       expect(file.data.text()).toEqual('hello-world')
+    })
+
+    it('should upload collection with CIDs support', async () => {
+      const directoryStructure: Collection<Uint8Array> = [
+        {
+          path: '0',
+          data: new TextEncoder().encode('hello-CID-world'),
+        },
+      ]
+
+      const result = await bee.uploadCollection(getPostageBatch(), directoryStructure)
+      const file = await bee.downloadFile(result.cid, directoryStructure[0].path)
+
+      expect(file.name).toEqual(directoryStructure[0].path)
+      expect(file.data.text()).toEqual('hello-CID-world')
     })
   })
 

--- a/test/unit/bee-class.spec.ts
+++ b/test/unit/bee-class.spec.ts
@@ -16,6 +16,7 @@ import {
   testBatchId,
   testChunkHash,
   testIdentity,
+  testJsonCid,
   testJsonEns,
   testJsonHash,
   testJsonPayload,
@@ -85,6 +86,7 @@ describe('Bee class', () => {
     const reference = await bee.uploadFile(testBatchId, 'hello world', 'nice.txt')
 
     expect(reference).toEqual({
+      cid: testJsonCid,
       reference: testJsonHash,
       tagUid: 123,
     })
@@ -895,6 +897,7 @@ describe('Bee class', () => {
       const reference = await bee.uploadFile(testBatchId, 'hello world', 'nice.txt', { encrypt: true })
 
       expect(reference).toEqual({
+        cid: testJsonCid,
         reference: testJsonHash,
         tagUid: 123,
       })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -444,6 +444,7 @@ export const testBatchId = 'ca6357a08e317d15ec560fef34e4c45f8f19f01c372aa70f1da7
 export const testJsonPayload = [{ some: 'object' }]
 export const testJsonStringPayload = JSON.stringify(testJsonPayload)
 export const testJsonHash = '872a858115b8bee4408b1427b49e472883fdc2512d5a8f2d428b97ecc8f7ccfa'
+export const testJsonCid = 'bah5acgzaq4vilaivxc7oiqelcqt3jhshfcb73qsrfvni6lkcrol6zshxzt5a'
 export const testJsonEns = 'testing.eth'
 
 export const testIdentity = {


### PR DESCRIPTION
Closes #648 

The Feed CID is not returned for the `Bee.createFeedManifest()` as that would be breaking change. It is planned for the next breaking release.