### PR TITLE
fix: move sleep to have all code in src

### DIFF
--- a/src/bee-debug.ts
+++ b/src/bee-debug.ts
@@ -62,7 +62,7 @@ import * as tag from './modules/debug/tag'
 import * as stamps from './modules/debug/stamps'
 import type { Options as KyOptions } from 'ky-universal'
 import { makeDefaultKy, wrapRequestClosure, wrapResponseClosure } from './utils/http'
-import { sleep } from '../test/utils'
+import { sleep } from './utils/sleep'
 
 export class BeeDebug {
   /**

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,0 +1,8 @@
+/**
+ * Sleep for N miliseconds
+ *
+ * @param ms Number of miliseconds to sleep
+ */
+export async function sleep(ms: number): Promise<void> {
+  return new Promise<void>(resolve => setTimeout(() => resolve(), ms))
+}

--- a/test/integration/bee-class.spec.ts
+++ b/test/integration/bee-class.spec.ts
@@ -21,7 +21,6 @@ import {
   makeTestTarget,
   PSS_TIMEOUT,
   randomByteArray,
-  sleep,
   testChunkPayload,
   testIdentity,
   testJsonHash,
@@ -30,6 +29,7 @@ import {
 } from '../utils'
 import { Readable } from 'stream'
 import { TextEncoder } from 'util'
+import { sleep } from '../../src/utils/sleep'
 
 commonMatchers()
 

--- a/test/integration/bee-debug-class.spec.ts
+++ b/test/integration/bee-debug-class.spec.ts
@@ -4,9 +4,9 @@ import {
   commonMatchers,
   getOrCreatePostageBatch,
   BLOCKCHAIN_TRANSACTION_TIMEOUT,
-  sleep,
   WAITING_USABLE_STAMP_TIMEOUT,
 } from '../utils'
+import { sleep } from '../../src/utils/sleep'
 
 commonMatchers()
 

--- a/test/integration/modules/debug/chequebook.spec.ts
+++ b/test/integration/modules/debug/chequebook.spec.ts
@@ -7,7 +7,8 @@ import {
 } from '../../../../src/modules/debug/chequebook'
 import { NumberString } from '../../../../src/types'
 import { isPrefixedHexString } from '../../../../src/utils/hex'
-import { beeDebugKy, commonMatchers, sleep } from '../../../utils'
+import { beeDebugKy, commonMatchers } from '../../../utils'
+import { sleep } from '../../../../src/utils/sleep'
 
 if (process.env.BEE_TEST_CHEQUEBOOK) {
   commonMatchers()

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -4,19 +4,20 @@ import { ReadableStream as ReadableStreamPolyfill } from 'web-streams-polyfill'
 import ky from 'ky-universal'
 
 import type {
-  Ky,
-  BeeGenericResponse,
-  Reference,
   Address,
   BatchId,
-  PostageBatch,
+  BeeGenericResponse,
+  Ky,
   PlainBytesReference,
+  PostageBatch,
+  Reference,
 } from '../src/types'
 import { bytesToHex, HexString } from '../src/utils/hex'
 import { deleteChunkFromLocalStorage } from '../src/modules/debug/chunk'
 import { BeeResponseError } from '../src'
 import { assertBytes } from '../src/utils/bytes'
 import * as stamps from '../src/modules/debug/stamps'
+import { sleep } from '../src/utils/sleep'
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -116,15 +117,6 @@ export function commonMatchers(): void {
           }
     },
   })
-}
-
-/**
- * Sleep for N miliseconds
- *
- * @param ms Number of miliseconds to sleep
- */
-export async function sleep(ms: number): Promise<void> {
-  return new Promise<void>(resolve => setTimeout(() => resolve(), ms))
 }
 
 /**


### PR DESCRIPTION
So... 😅

My IDE was trigger-happy and I haven't noticed it. When implementing the `waitForUsable` feature, I have copy&pasted Aron's solution, which used the `sleep` function and IDE noticed that we have this function in `test/utils.ts` file so it just imported that and I have not noticed that.

Thanks to this the `tsc` compilation changed the structure of the compiled files as it has to now import something from `./test` folder and so it changed the `./dist/cjs/` folder structure into containing subfolders `src` and `test` as this:

```
cjs
├── package.json
├── src
│   ├── bee-debug.js
│   ├── bee.js
│   ├── chunk
│   ├── feed
│   ├── index.js
│   ├── modules
│   ├── types
│   └── utils
└── test
    └── utils.js
```

This, unfortunately, breaks the package as the entry file `./dist/cjs/index.js` is not in the expected place.