### PR TITLE
ci: update the bee-update workflow

### DIFF
--- a/.github/workflows/update_bee.yaml
+++ b/.github/workflows/update_bee.yaml
@@ -3,8 +3,8 @@ name: Update Bee version
 on:
   workflow_dispatch:
     inputs:
-      beeFactoryImageVersion:
-        description: 'Bee Factory image version (eq. 1.3.0)'
+      beeVersion:
+        description: 'Bee version (eq. 1.3.0)'
         required: true
       beeApiVersion:
         description: 'Bee API version (eq. 1.3.0)'
@@ -28,20 +28,18 @@ jobs:
       - name: Set env. variables
         run: |
           if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
-            image_version=$(echo "${{ github.event.client_payload.imageVersion }}" | xargs )
+            bee_version=$(echo "${{ github.event.client_payload.beeVersion }}" | xargs )
             bee_api_version=$(echo "${{ github.event.client_payload.apiVersion }}" | xargs )
             bee_debug_api_version=$(echo "${{ github.event.client_payload.debugApiVersion }}" | xargs )
           else
-            image_version=$(echo "${{ github.event.inputs.beeFactoryImageVersion }}" | xargs )
+            bee_version=$(echo "${{ github.event.inputs.beeVersion }}" | xargs )
             bee_api_version=$(echo "${{ github.event.inputs.beeApiVersion }}" | xargs )
             bee_debug_api_version=$(echo "${{ github.event.inputs.beeDebugApiVersion }}" | xargs )
           fi
 
-          bee_version=${image_version/-stateful}
-          echo "IMAGE_VERSION=$image_version" >> $GITHUB_ENV
-          echo "BEE_VERSION=$bee_version" >> $GITHUB_ENV
-          echo "TARGET_BRANCH=${bee_version/-rc*}" >> $GITHUB_ENV
-          echo "RELEASE_NAME=${bee_version%-*}" >> $GITHUB_ENV
+          echo "BEE_VERSION_WITH_COMMIT=$bee_version" >> $GITHUB_ENV
+          echo "FINAL_CLEAN_BEE_VERSION=${bee_version/-*}" >> $GITHUB_ENV
+          echo "CLEAN_BEE_VERSION=${bee_version%-*}" >> $GITHUB_ENV
           echo "API_VERSION=$bee_api_version" >> $GITHUB_ENV
           echo "DEBUG_API_VERSION=$bee_debug_api_version" >> $GITHUB_ENV
 
@@ -50,7 +48,7 @@ jobs:
         with:
           file: package.json
           field: engines.bee
-          value: ${{ env.BEE_VERSION }}
+          value: ${{ env.BEE_VERSION_WITH_COMMIT }}
 
       - name: Replace API version in package.json
         uses: jossef/action-set-json-field@v1
@@ -73,7 +71,7 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v2
         with:
           find: "export const SUPPORTED_BEE_VERSION_EXACT = '.*?'"
-          replace: "export const SUPPORTED_BEE_VERSION_EXACT = '${{ env.BEE_VERSION }}'"
+          replace: "export const SUPPORTED_BEE_VERSION_EXACT = '${{ env.BEE_VERSION_WITH_COMMIT }}'"
           include: "src/modules/debug/status.ts"
           regex: true
 
@@ -97,7 +95,7 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v2
         with:
           find: "<!-- SUPPORTED_BEE_START -->.*?<!-- SUPPORTED_BEE_END -->"
-          replace: "<!-- SUPPORTED_BEE_START -->${{ env.TARGET_BRANCH }}<!-- SUPPORTED_BEE_END -->"
+          replace: "<!-- SUPPORTED_BEE_START -->${{ env.FINAL_CLEAN_BEE_VERSION }}<!-- SUPPORTED_BEE_END -->"
           include: README.md
           regex: true
 
@@ -107,9 +105,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_GHA_PAT }}
         with:
-          title: "chore: update to bee ${{ env.BEE_VERSION }}"
-          body: "Updated Bee version ${{ env.BEE_VERSION }}"
-          branch: "bee-${{ env.TARGET_BRANCH }}"
+          title: "chore: update to bee ${{ env.FINAL_CLEAN_BEE_VERSION }}"
+          body: "Updated Bee version ${{ env.BEE_VERSION_WITH_COMMIT }}"
+          branch: "bee-${{ env.FINAL_CLEAN_BEE_VERSION }}"
           commit-message: "chore: update to bee"
           author: "bee-worker <bee-worker@ethswarm.org>"
 
@@ -118,7 +116,7 @@ jobs:
         with:
           owner: ethersphere
           repo: bee
-          tag_name: v${{ env.RELEASE_NAME }}
+          tag_name: v${{ env.CLEAN_BEE_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_GHA_PAT }}
 
@@ -140,6 +138,6 @@ jobs:
           comment-id: ${{ steps.comment.outputs.comment-id }}
           issue-number: ${{ steps.pr.outputs.pull-request-number }}
           body: |
-            ## 🗒 Bee ${{ env.BEE_VERSION }} Release notes
+            ## 🗒 Bee ${{ env.CLEAN_BEE_VERSION }} Release notes
 
             ${{ steps.release-notes.outputs.body}}


### PR DESCRIPTION
- Improves the variable naming
- Cleans up some variables from the old way of upgrading the Bee Factory images
- Fixes the fact that the update created two PRs. One for the RC's versions and then one for the final Bee version.
- Blocked by https://github.com/ethersphere/bee-factory/pull/175