### PR TITLE
fix: wrong JSDoc links

### DIFF
--- a/src/bee.ts
+++ b/src/bee.ts
@@ -1295,7 +1295,7 @@ export class Bee {
    * @throws TypeError if tagUid is in not correct format
    *
    * @see [Bee docs - Syncing / Tags](https://docs.ethswarm.org/docs/develop/access-the-swarm/syncing)
-   * @see [Bee API reference - `GET /tags/{uid}`](https://docs.ethswarm.org/debug-api/#tag/Tag)
+   * @see [Bee API reference - `GET /tags/{uid}`](https://docs.ethswarm.org/api/#tag/Tag/paths/~1tags~1{uid}/get)
    *
    */
   async retrieveExtendedTag(tagUid: number | Tag, options?: BeeRequestOptions): Promise<ExtendedTag> {
@@ -1688,7 +1688,7 @@ export class Bee {
    * @throws TypeError if non-integer value is passed to amount or depth
    *
    * @see [Bee docs - Keep your data alive / Postage stamps](https://docs.ethswarm.org/docs/develop/access-the-swarm/introduction/#keep-your-data-alive)
-   * @see [Bee Debug API reference - `POST /stamps`](https://docs.ethswarm.org/debug-api/#tag/Postage-Stamps/paths/~1stamps~1{amount}~1{depth}/post)
+   * @see [Bee API reference - `POST /stamps`](https://docs.ethswarm.org/api/#tag/Postage-Stamps/paths/~1stamps~1{amount}~1{depth}/post)
    */
   async createPostageBatch(
     amount: NumberString,
@@ -1735,7 +1735,7 @@ export class Bee {
    * @param options Request options
    *
    * @see [Bee docs - Keep your data alive / Postage stamps](https://docs.ethswarm.org/docs/develop/access-the-swarm/introduction/#keep-your-data-alive)
-   * @see [Bee Debug API reference - `PATCH /stamps/topup/${id}/${amount}`](https://docs.ethswarm.org/debug-api/#tag/Postage-Stamps/paths/~1stamps~1topup~1{id}~1{amount}/patch)
+   * @see [Bee API reference - `PATCH /stamps/topup/${id}/${amount}`](https://docs.ethswarm.org/api/#tag/Postage-Stamps/paths/~1stamps~1topup~1{batch_id}~1{amount}/patch)
    */
   async topUpBatch(postageBatchId: BatchId | string, amount: NumberString, options?: BeeRequestOptions): Promise<void> {
     assertRequestOptions(options)
@@ -1759,7 +1759,7 @@ export class Bee {
    * @param options Request options
    *
    * @see [Bee docs - Keep your data alive / Postage stamps](https://docs.ethswarm.org/docs/develop/access-the-swarm/introduction/#keep-your-data-alive)
-   * @see [Bee Debug API reference - `PATCH /stamps/topup/${id}/${amount}`](https://docs.ethswarm.org/debug-api/#tag/Postage-Stamps/paths/~1stamps~1topup~1{id}~1{amount}/patch)
+   * @see [Bee API reference - `PATCH /stamps/topup/${id}/${amount}`](https://docs.ethswarm.org/api/#tag/Postage-Stamps/paths/~1stamps~1topup~1{batch_id}~1{amount}/patch)
    */
   async diluteBatch(postageBatchId: BatchId | string, depth: number, options?: BeeRequestOptions): Promise<void> {
     assertRequestOptions(options)
@@ -1775,7 +1775,7 @@ export class Bee {
    * @param postageBatchId Batch ID
    *
    * @see [Bee docs - Keep your data alive / Postage stamps](https://docs.ethswarm.org/docs/develop/access-the-swarm/introduction/#keep-your-data-alive)
-   * @see [Bee Debug API reference - `GET /stamps/${id}`](https://docs.ethswarm.org/debug-api/#tag/Postage-Stamps/paths/~1stamps~1{id}/get)
+   * @see [Bee API reference - `GET /stamps/${id}`](https://docs.ethswarm.org/api/#tag/Postage-Stamps/paths/~1stamps~1{batch_id}/get)
    */
   async getPostageBatch(postageBatchId: BatchId | string, options?: BeeRequestOptions): Promise<PostageBatch> {
     assertRequestOptions(options)
@@ -1790,7 +1790,7 @@ export class Bee {
    * @param postageBatchId Batch ID
    *
    * @see [Bee docs - Keep your data alive / Postage stamps](https://docs.ethswarm.org/docs/develop/access-the-swarm/introduction/#keep-your-data-alive)
-   * @see [Bee Debug API reference - `GET /stamps/${id}/buckets`](https://docs.ethswarm.org/debug-api/#tag/Postage-Stamps/paths/~1stamps~1{id}~1buckets/get)
+   * @see [Bee API reference - `GET /stamps/${id}/buckets`](https://docs.ethswarm.org/api/#tag/Postage-Stamps/paths/~1stamps~1{batch_id}~1buckets/get)
    */
   async getPostageBatchBuckets(
     postageBatchId: BatchId | string,
@@ -1806,7 +1806,7 @@ export class Bee {
    * Return all postage batches that has the node available.
    *
    * @see [Bee docs - Keep your data alive / Postage stamps](https://docs.ethswarm.org/docs/develop/access-the-swarm/introduction/#keep-your-data-alive)
-   * @see [Bee Debug API reference - `GET /stamps`](https://docs.ethswarm.org/debug-api/#tag/Postage-Stamps/paths/~1stamps/get)
+   * @see [Bee API reference - `GET /stamps`](https://docs.ethswarm.org/api/#tag/Postage-Stamps/paths/~1stamps/get)
    */
   async getAllPostageBatch(options?: BeeRequestOptions): Promise<PostageBatch[]> {
     assertRequestOptions(options)

--- a/src/types/debug.ts
+++ b/src/types/debug.ts
@@ -211,14 +211,14 @@ export interface NodeInfo {
   /**
    * Indicates whether the Bee node has its own deployed chequebook.
    *
-   * @see [Bee docs - Chequebook](https://docs.ethswarm.org/docs/learn/glossary#cheques--chequebook)
+   * @see [Bee docs - Chequebook](https://docs.ethswarm.org/docs/references/glossary/#cheques--chequebook)
    */
   chequebookEnabled: boolean
 
   /**
    * Indicates whether SWAP is enabled for the Bee node.
    *
-   * @see [Bee docs - SWAP](https://docs.ethswarm.org/docs/learn/glossary#swap)
+   * @see [Bee docs - SWAP](https://docs.ethswarm.org/docs/references/glossary/#swap)
    */
   swapEnabled: boolean
 }


### PR DESCRIPTION
- `/debug-api/` ->`/api/`
- `{id`} -> `{batchid}`