### PR TITLE
feat: add recursive ACT support for mantaray structures

### DIFF
--- a/test/integration/manifest.spec.ts
+++ b/test/integration/manifest.spec.ts
@@ -131,3 +131,165 @@ test('Manifest add fork with foreign path', async () => {
   expect(items['c/中文/index.xml']).toBeDefined()
   expect(items['c/中文/index.html']).toBeDefined()
 })
+
+test('Manifest save/load with ACT stores history address in fork metadata', async () => {
+  const bee = makeBee()
+
+  const ref1 = arbitraryReference()
+  const ref2 = arbitraryReference()
+
+  const node = new MantarayNode()
+  node.addFork('folder/file1.txt', ref1, { 'Content-Type': 'text/plain' })
+  node.addFork('folder/file2.txt', ref2, { 'Content-Type': 'text/plain' })
+
+  const result = await node.saveRecursively(bee, batch(), { act: true })
+
+  expect(result.reference.toHex()).toHaveLength(64)
+  expect(result.historyAddress.getOrThrow().toHex()).toHaveLength(64)
+})
+
+test('Manifest save/load with ACT preserves structure', async () => {
+  const bee = makeBee()
+  const { publicKey } = await bee.getNodeAddresses()
+
+  const fileData = 'test file content for ACT preservation'
+  const fileUpload = await bee.uploadData(batch(), fileData)
+
+  const node = new MantarayNode()
+  node.addFork('deep/nested/file.txt', fileUpload.reference, {
+    'Content-Type': 'text/plain',
+    Filename: 'file.txt',
+  })
+
+  const result = await node.saveRecursively(bee, batch(), { act: true })
+  const rootHistoryAddress = result.historyAddress.getOrThrow()
+
+  const loadedNode = await MantarayNode.unmarshal(bee, result.reference, {
+    actHistoryAddress: rootHistoryAddress,
+    actPublisher: publicKey,
+  })
+
+  await loadedNode.loadRecursively(bee, { actPublisher: publicKey })
+
+  const mapping = loadedNode.collectAndMap()
+
+  expect(mapping['deep/nested/file.txt']).toBeDefined()
+  expect(mapping['deep/nested/file.txt']).toBe(fileUpload.reference.toHex())
+})
+
+test('Manifest save/load with ACT nested folders', async () => {
+  const bee = makeBee()
+  const { publicKey } = await bee.getNodeAddresses()
+
+  const file1 = await bee.uploadData(batch(), 'content-1')
+  const file2 = await bee.uploadData(batch(), 'content-2')
+  const file3 = await bee.uploadData(batch(), 'content-3')
+
+  const node = new MantarayNode()
+  node.addFork('a/b/c/file1.txt', file1.reference)
+  node.addFork('a/b/file2.txt', file2.reference)
+  node.addFork('a/file3.txt', file3.reference)
+
+  const result = await node.saveRecursively(bee, batch(), { act: true })
+
+  const loadedNode = await MantarayNode.unmarshal(bee, result.reference, {
+    actHistoryAddress: result.historyAddress.getOrThrow(),
+    actPublisher: publicKey,
+  })
+
+  await loadedNode.loadRecursively(bee, { actPublisher: publicKey })
+
+  const mapping = loadedNode.collectAndMap()
+
+  expect(Object.keys(mapping)).toHaveLength(3)
+  expect(mapping['a/b/c/file1.txt']).toBe(file1.reference.toHex())
+  expect(mapping['a/b/file2.txt']).toBe(file2.reference.toHex())
+  expect(mapping['a/file3.txt']).toBe(file3.reference.toHex())
+})
+
+test('Manifest save/load with ACT can download and verify content', async () => {
+  const bee = makeBee()
+  const { publicKey } = await bee.getNodeAddresses()
+
+  const originalContent = 'This is the secret content that should be encrypted and decrypted correctly!'
+  const fileUpload = await bee.uploadData(batch(), originalContent)
+
+  const node = new MantarayNode()
+  node.addFork('secret/data.txt', fileUpload.reference, {
+    'Content-Type': 'text/plain',
+    Filename: 'data.txt',
+  })
+
+  const result = await node.saveRecursively(bee, batch(), { act: true })
+
+  const loadedNode = await MantarayNode.unmarshal(bee, result.reference, {
+    actHistoryAddress: result.historyAddress.getOrThrow(),
+    actPublisher: publicKey,
+  })
+
+  await loadedNode.loadRecursively(bee, { actPublisher: publicKey })
+
+  const mapping = loadedNode.collectAndMap()
+  const fileReference = mapping['secret/data.txt']
+
+  expect(fileReference).toBeDefined()
+
+  const downloadedData = await bee.downloadData(fileReference)
+  expect(downloadedData.toUtf8()).toBe(originalContent)
+})
+
+test('Manifest save/load with ACT single file at root', async () => {
+  const bee = makeBee()
+  const { publicKey } = await bee.getNodeAddresses()
+
+  const content = 'root-level-file-content'
+  const fileUpload = await bee.uploadData(batch(), content)
+
+  const node = new MantarayNode()
+  node.addFork('readme.txt', fileUpload.reference)
+
+  const result = await node.saveRecursively(bee, batch(), { act: true })
+
+  const loadedNode = await MantarayNode.unmarshal(bee, result.reference, {
+    actHistoryAddress: result.historyAddress.getOrThrow(),
+    actPublisher: publicKey,
+  })
+
+  await loadedNode.loadRecursively(bee, { actPublisher: publicKey })
+
+  const mapping = loadedNode.collectAndMap()
+
+  expect(Object.keys(mapping)).toHaveLength(1)
+  expect(mapping['readme.txt']).toBe(fileUpload.reference.toHex())
+})
+
+test('Manifest save/load with ACT preserves existing metadata', async () => {
+  const bee = makeBee()
+  const { publicKey } = await bee.getNodeAddresses()
+
+  const fileUpload = await bee.uploadData(batch(), 'test-content')
+
+  const node = new MantarayNode()
+  node.addFork('file.txt', fileUpload.reference, {
+    'Content-Type': 'text/plain',
+    'Custom-Header': 'custom-value',
+    Filename: 'file.txt',
+  })
+
+  const result = await node.saveRecursively(bee, batch(), { act: true })
+
+  const loadedNode = await MantarayNode.unmarshal(bee, result.reference, {
+    actHistoryAddress: result.historyAddress.getOrThrow(),
+    actPublisher: publicKey,
+  })
+
+  await loadedNode.loadRecursively(bee, { actPublisher: publicKey })
+
+  const values = loadedNode.collect()
+  const fileNode = values.find(v => v.fullPathString === 'file.txt')
+
+  expect(fileNode).toBeDefined()
+  expect(fileNode?.metadata?.['Content-Type']).toBe('text/plain')
+  expect(fileNode?.metadata?.['Custom-Header']).toBe('custom-value')
+  expect(fileNode?.metadata?.['Filename']).toBe('file.txt')
+})


### PR DESCRIPTION
🔖 Title
Add recursive ACT support for mantaray structures

📝 Description
This PR implements recursive ACT support in the MantarayNode class, enabling encrypted manifest structures to be properly saved and loaded with ACT protection across nested folder hierarchies.

Changes
- Modified saveRecursively() to capture and store swarm-act-history-address in fork metadata when ACT is enabled
- Modified loadRecursively() to read history address from fork metadata and pass it to child node unmarshalling for proper ACT decryption

🧪 How Has This Been Tested?
✅ Tested with integration tests in manifest.spec.ts