### PR TITLE
fix: streamable data upload and preserve http request data

### DIFF
--- a/src/api/bytes.ts
+++ b/src/api/bytes.ts
@@ -1,4 +1,5 @@
 import { Optional } from 'cafe-utility'
+import { Readable } from 'stream'
 import type { BeeRequestOptions, DownloadOptions, RedundantUploadOptions, ReferenceInformation } from '../types'
 import { UploadResult } from '../types'
 import { UploadResultBody } from '../types/schema/upload'
@@ -18,7 +19,7 @@ const endpoint = 'bytes'
 
 export async function upload(
   requestOptions: BeeRequestOptions,
-  data: string | Uint8Array,
+  data: string | Uint8Array | Blob | Readable,
   postageBatchId: BatchId,
   options?: RedundantUploadOptions,
 ): Promise<UploadResult> {

--- a/src/modules/data.ts
+++ b/src/modules/data.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'stream'
 import type {
   BeeRequestOptions,
   DownloadOptions,
@@ -34,7 +35,7 @@ export class Data {
    */
   async upload(
     postageBatchId: BatchId | Uint8Array | string,
-    data: string | Uint8Array,
+    data: string | Uint8Array | Blob | Readable,
     options?: RedundantUploadOptions,
     requestOptions?: BeeRequestOptions,
   ): Promise<UploadResult> {

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -39,7 +39,13 @@ export interface BeeRequestConfig extends RequestInit {
  * @param config Internal settings and/or Bee settings
  */
 export async function http<T>(options: BeeRequestOptions, config: BeeRequestConfig): Promise<BeeResponse<T>> {
-  const requestConfig: BeeRequestConfig = Objects.deepMerge3(DEFAULT_HTTP_CONFIG, config, options)
+  const rawData = config.data
+  const requestConfig: BeeRequestConfig = Objects.deepMerge3(
+    DEFAULT_HTTP_CONFIG,
+    { ...config, data: undefined },
+    options,
+  )
+  requestConfig.data = rawData
 
   if (options.signal) {
     requestConfig.signal = options.signal

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -36,9 +36,9 @@ export function isTag(value: unknown): value is Tag {
  * @param value
  * @throws TypeError if not valid
  */
-export function assertData(value: unknown): asserts value is string | Uint8Array {
-  if (typeof value !== 'string' && !(value instanceof Uint8Array)) {
-    throw new TypeError('Data must be either string or Uint8Array!')
+export function assertData(value: unknown): asserts value is string | Uint8Array | Blob | stream.Readable {
+  if (typeof value !== 'string' && !(value instanceof Uint8Array) && !(value instanceof Blob) && !isReadable(value)) {
+    throw new TypeError('Data must be either string, Uint8Array, Blob or Readable!')
   }
 }
 


### PR DESCRIPTION
Extend function arguments for data.upload to enable streaming upload via the /bytes api endpoint.
Fix the missing request body for http calls that gets overwritten by Objects.deepMerge3.